### PR TITLE
keeper test fixing

### DIFF
--- a/x/zktx/keeper/gnark/gnark.go
+++ b/x/zktx/keeper/gnark/gnark.go
@@ -26,6 +26,8 @@ type HyleCircuit struct {
 	IdentityLen frontend.Variable   `gnark:",public"` // This is encoded as a single ASCII character per byte
 	Identity    [256]uints.U8       `gnark:",public"` // The max capacity is 256 bytes (arbitrarily, but we need something static)
 	TxHash      [64]uints.U8        `gnark:",public"`
+	PayloadHash [32]uints.U8        `gnark:",public"`
+	Success     frontend.Variable   `gnark:",public"`
 }
 
 func (c *HyleCircuit) Define(api frontend.API) error { return nil }
@@ -117,6 +119,12 @@ func parseString(input *fr.Vector) (string, error) {
 	}
 }
 
+func parseBool(input *fr.Vector) bool {
+	b := (*input)[0].Uint64() == 1
+	*input = (*input)[1:]
+	return b
+}
+
 func (proof *Groth16Proof) ExtractData(witness witness.Witness) (*zktx.HyleOutput, error) {
 	// Check payload version identifier
 	pubWitVector, ok := witness.Vector().(fr.Vector)
@@ -144,6 +152,11 @@ func (proof *Groth16Proof) ExtractData(witness witness.Witness) (*zktx.HyleOutpu
 	if output.TxHash, err = parseArray(&slice, 64); err != nil {
 		return nil, err
 	}
+
+	if output.PayloadHash, err = parseArray(&slice, 32); err != nil {
+		return nil, err
+	}
+	output.Success = parseBool(&slice)
 
 	return output, nil
 }

--- a/x/zktx/keeper/gnark/gnark.go
+++ b/x/zktx/keeper/gnark/gnark.go
@@ -53,6 +53,16 @@ func ToArray64(d []byte) [64]uints.U8 {
 	return [64]uints.U8(uints.NewU8Array(d))
 }
 
+func ToArray32(d []byte) [32]uints.U8 {
+	// Pad to 32
+	if len(d) < 32 {
+		padded := make([]byte, 32)
+		copy(padded, d)
+		d = padded
+	}
+	return [32]uints.U8(uints.NewU8Array(d))
+}
+
 // Struct type expected for the "proof" argument
 type Groth16Proof struct {
 	Proof         []byte `json:"proof"`

--- a/x/zktx/keeper/msg_server.go
+++ b/x/zktx/keeper/msg_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 	pedersenhash "github.com/consensys/gnark-crypto/ecc/stark-curve/pedersen-hash"
 	"github.com/consensys/gnark/backend/groth16"
+	gosha3 "golang.org/x/crypto/sha3"
 )
 
 type msgServer struct {
@@ -103,6 +104,12 @@ func computePayloadHash(verifier string, payloadData []byte) ([]byte, error) {
 		return make([]byte, 4), nil
 	} else if verifier == "risczero" {
 		return payloadData, nil
+	} else if verifier == "gnark-groth16-te-BN254" {
+		hasher := gosha3.NewLegacyKeccak256()
+		if _, err := hasher.Write(payloadData); err != nil {
+			return nil, err
+		}
+		return hasher.Sum(nil), nil
 	}
 	return nil, fmt.Errorf("failed to hash payload: hash function not implemented for verifier %s", verifier)
 }

--- a/x/zktx/keeper/msg_server_ecdsa_test.go
+++ b/x/zktx/keeper/msg_server_ecdsa_test.go
@@ -130,23 +130,24 @@ func limbsToBytes(u64api *uints.BinaryField[uints.U64], limbs []frontend.Variabl
 	return result
 }
 
-func generate_ecdsa_proof(privKey *ecdsa.PrivateKey, ethAddress string, sigBin *[]byte) (gnark.Groth16Proof, error) {
-	publicKey := privKey.PublicKey
-
-	// sign
-	msg := []byte("testing ECDSA (sha256)")
+func sign(privKey *ecdsa.PrivateKey, msg []byte) ([]byte, error) {
+	byteMsg := []byte(msg)
 	md := sha256.New()
-	*sigBin, _ = privKey.Sign(msg, md)
+	sig, _ := privKey.Sign(byteMsg, md)
 
 	// check that the signature is correct
-	flag, _ := publicKey.Verify(*sigBin, msg, md)
+	publicKey := privKey.PublicKey
+	flag, _ := publicKey.Verify(sig, byteMsg, md)
 	if !flag {
-		return gnark.Groth16Proof{}, fmt.Errorf("invalid signature")
+		return sig, fmt.Errorf("invalid signature")
 	}
+	return sig, nil
+}
 
+func makeECDSACircuit(privKey *ecdsa.PrivateKey, ethAddress string, sigBin, msg []byte) (*ecdsaCircuit[emulated.Secp256k1Fp, emulated.Secp256k1Fr], error) {
 	// unmarshal signature
 	var sig ecdsa.Signature
-	sig.SetBytes(*sigBin)
+	sig.SetBytes(sigBin)
 	r, s := new(big.Int), new(big.Int)
 	r.SetBytes(sig.R[:32])
 	s.SetBytes(sig.S[:32])
@@ -154,17 +155,17 @@ func generate_ecdsa_proof(privKey *ecdsa.PrivateKey, ethAddress string, sigBin *
 	// compute the hash of the message as an integer
 	dataToHash := make([]byte, len(msg))
 	copy(dataToHash[:], msg[:])
-	md.Reset()
+	md := sha256.New()
 	md.Write(dataToHash[:])
 	hramBin := md.Sum(nil)
 	hash := ecdsa.HashToInt(hramBin)
 
-	payloadHash, err := computePayloadHash(*sigBin)
+	payloadHash, err := computePayloadHash(sigBin)
 	if err != nil {
-		return gnark.Groth16Proof{}, err
+		return nil, err
 	}
 
-	circuit := ecdsaCircuit[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
+	return &ecdsaCircuit[emulated.Secp256k1Fp, emulated.Secp256k1Fr]{
 		HyleCircuit: gnark.HyleCircuit{
 			Version:     1,
 			InputLen:    1,
@@ -186,20 +187,22 @@ func generate_ecdsa_proof(privKey *ecdsa.PrivateKey, ethAddress string, sigBin *
 			X: emulated.ValueOf[emulated.Secp256k1Fp](privKey.PublicKey.A.X),
 			Y: emulated.ValueOf[emulated.Secp256k1Fp](privKey.PublicKey.A.Y),
 		},
-	}
+	}, nil
+}
 
-	err = test.IsSolved(&circuit, &circuit, ecc.BN254.ScalarField())
+func generate_ecdsa_proof(circuit *ecdsaCircuit[emulated.Secp256k1Fp, emulated.Secp256k1Fr]) (gnark.Groth16Proof, error) {
+	err := test.IsSolved(circuit, circuit, ecc.BN254.ScalarField())
 	if err != nil {
 		return gnark.Groth16Proof{}, err
 	}
 
 	// Witness first then compile as that modifies the circuit
-	witness, err := frontend.NewWitness(&circuit, ecc.BN254.ScalarField())
+	witness, err := frontend.NewWitness(circuit, ecc.BN254.ScalarField())
 	if err != nil {
 		return gnark.Groth16Proof{}, err
 	}
 
-	r1cs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
+	r1cs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, circuit)
 	if err != nil {
 		return gnark.Groth16Proof{}, err
 	}
@@ -252,8 +255,14 @@ func TestExecuteStateChangesGroth16ECDSA(t *testing.T) {
 	pubkeyBytes := privKey.PublicKey.A.RawBytes()
 	ethAddress := hex.EncodeToString(nativesha3.Keccak256(pubkeyBytes[:])[12:]) + ".ecdsa"
 
-	var sigBin []byte
-	proof, err := generate_ecdsa_proof(privKey, ethAddress, &sigBin)
+	txt := []byte("testing ECDSA (sha256)")
+	sigBin, err := sign(privKey, txt)
+	require.NoError(err)
+
+	circuit, err := makeECDSACircuit(privKey, ethAddress, sigBin, txt)
+	require.NoError(err)
+
+	proof, err := generate_ecdsa_proof(circuit)
 	require.NoError(err)
 	jsonproof, _ := json.Marshal(proof)
 
@@ -296,4 +305,29 @@ func TestExecuteStateChangesGroth16ECDSA(t *testing.T) {
 
 	st, _ := f.k.Contracts.Get(f.ctx, "ecdsa")
 	require.Equal(st.StateDigest, []byte{0})
+}
+
+func TestBadPayloadGroth16ECDSA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping ECDSA, takes a minute on my machine.")
+	}
+
+	require := require.New(t)
+
+	privKey, _ := ecdsa.GenerateKey(rand.Reader)
+	pubkeyBytes := privKey.PublicKey.A.RawBytes()
+	ethAddress := hex.EncodeToString(nativesha3.Keccak256(pubkeyBytes[:])[12:]) + ".ecdsa"
+
+	txt := []byte("testing ECDSA (sha256)")
+	sigBin, err := sign(privKey, txt)
+	require.NoError(err)
+
+	circuit, err := makeECDSACircuit(privKey, ethAddress, sigBin, txt)
+	// corrupt payload hash
+	for i := 0; i < len(circuit.HyleCircuit.PayloadHash); i++ {
+		circuit.HyleCircuit.PayloadHash[i] = uints.NewU8(0)
+	}
+
+	_, err = generate_ecdsa_proof(circuit)
+	require.Error(err, "payload hash should mismatch")
 }

--- a/x/zktx/keeper/msg_server_groth16_test.go
+++ b/x/zktx/keeper/msg_server_groth16_test.go
@@ -224,6 +224,36 @@ func TestExecuteStateChangesGroth16(t *testing.T) {
 	require.Equal(st.StateDigest, final_state_witness)
 }
 
+func TestBadPayloadGroth16(t *testing.T) {
+	require := require.New(t)
+
+	// Parameters:
+	var initial_state = 1
+	var end_state = 4
+	contract_name := "test-contract"
+
+	// Generate the proof and marshal it
+	circuit := statefulCircuit{
+		OtherData: 3,
+		HyleCircuit: gnark.HyleCircuit{
+			Version:     1,
+			InputLen:    1,
+			Input:       []frontend.Variable{initial_state},
+			OutputLen:   1,
+			Output:      []frontend.Variable{end_state},
+			IdentityLen: len("toto." + contract_name),
+			Identity:    gnark.ToArray256([]byte("toto." + contract_name)),
+			TxHash:      gnark.ToArray64([]byte("TODO")),
+			// do not set PayloadHash
+			Success: 1,
+		},
+		StillMoreData: 0,
+	}
+
+	_, err := generate_proof(&circuit)
+	require.Error(err, "payload hash should mismatch")
+}
+
 func TestExecuteLongStateChangeGroth16(t *testing.T) {
 	f := initFixture(t)
 	require := require.New(t)


### PR DESCRIPTION
- add PayloadHash and Success to HyleCircuit
- compute the payload hash in both groth16 and ecdsa tests.