### PR TITLE
✨ Relay messages from & to network

### DIFF
--- a/master.ron
+++ b/master.ron
@@ -5,5 +5,8 @@ Config(
     storage: Storage(
       interval: 10
     ),
-    rest: "127.0.0.1:4321"
+    rest: "127.0.0.1:4321",
+  p2p: (
+    ping_interval: 10
+  )
 )

--- a/slave.ron
+++ b/slave.ron
@@ -7,5 +7,8 @@ Config(
     storage: Storage(
       interval: 10
     ),
-    rest: "127.0.0.1:4322"
+    rest: "127.0.0.1:4322",
+  p2p: (
+    ping_interval: 10
+  )
 )

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use hyle::{
     model::{Transaction, TransactionData},
-    p2p::network::NetMessage,
+    p2p::network::{MempoolNetMessage, NetMessage},
     utils::conf::{self, SharedConf},
 };
 use rand::{distributions::Alphanumeric, Rng};
@@ -10,7 +10,7 @@ use tokio::{io::AsyncWriteExt, net::TcpStream, time::Duration};
 use tracing::info;
 
 pub fn new_transaction() -> Vec<u8> {
-    NetMessage::NewTransaction(Transaction {
+    NetMessage::MempoolMessage(MempoolNetMessage::NewTx(Transaction {
         inner: rand::thread_rng()
             .sample_iter(&Alphanumeric)
             .take(7)
@@ -18,7 +18,7 @@ pub fn new_transaction() -> Vec<u8> {
             .collect(),
         version: 1,
         transaction_data: TransactionData::default(),
-    })
+    }))
     .to_binary()
 }
 

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -33,12 +33,11 @@ pub async fn client(config: SharedConf) -> Result<()> {
         socket
             .write_u32(res.len() as u32)
             .await
-            .context("sending message")?;
-
+            .context("sending tcp message size")?;
         socket
             .write(res.as_ref())
             .await
-            .context("sending message")?;
+            .context("sending tcp message")?;
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -91,7 +91,12 @@ impl Consensus {
         Ok(ctx)
     }
 
-    pub async fn start(&mut self, bus: SharedMessageBus, config: SharedConf) -> Result<()> {
+    pub async fn start(
+        &mut self,
+        bus: SharedMessageBus,
+        net_bus: SharedMessageBus,
+        config: SharedConf,
+    ) -> Result<()> {
         let interval = config.storage.interval;
         let is_master = config.peers.is_empty();
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -8,7 +8,7 @@ use crate::{
     bus::SharedMessageBus,
     mempool::{MempoolCommand, MempoolResponse},
     model::{get_current_timestamp, Block, Hashable, Transaction},
-    p2p::network::{ConsensusNetMessage, NetCommand},
+    p2p::network::{ConsensusNetMessage, NetInput},
     utils::{conf::SharedConf, logger::LogMe},
 };
 
@@ -93,7 +93,7 @@ impl Consensus {
         Ok(ctx)
     }
 
-    fn handle_net_command(&mut self, msg: NetCommand<ConsensusNetMessage>) {
+    fn handle_net_input(&mut self, msg: NetInput<ConsensusNetMessage>) {
         match msg.msg {
             ConsensusNetMessage::CommitBlock(block) => {
                 info!("Got a commited block {:?}", block)
@@ -130,8 +130,8 @@ impl Consensus {
         let mut consensus_command_receiver = bus.receiver::<ConsensusCommand>().await;
         let mempool_command_sender = bus.sender::<MempoolCommand>().await;
         let mut mempool_response_receiver = bus.receiver::<MempoolResponse>().await;
-        let mut consensus_net_command_receiver =
-            bus.receiver::<NetCommand<ConsensusNetMessage>>().await;
+        let mut consensus_net_input_receiver =
+            bus.receiver::<NetInput<ConsensusNetMessage>>().await;
 
         if is_master {
             info!(
@@ -172,8 +172,8 @@ impl Consensus {
                         }
                     }
                 }
-                Ok(msg) = consensus_net_command_receiver.recv() => {
-                    self.handle_net_command(msg);
+                Ok(msg) = consensus_net_input_receiver.recv() => {
+                    self.handle_net_input(msg);
                 }
             }
         }

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,5 +1,6 @@
 use crate::{
-    bus::SharedMessageBus, model::Transaction, p2p::network::MempoolMessage, utils::logger::LogMe,
+    bus::SharedMessageBus, model::Transaction, p2p::network::MempoolNetMessage,
+    utils::logger::LogMe,
 };
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -45,14 +46,14 @@ impl Mempool {
     }
 
     /// start starts the mempool server.
-    pub async fn start(&mut self, mut message_receiver: UnboundedReceiver<MempoolMessage>) {
+    pub async fn start(&mut self, mut message_receiver: UnboundedReceiver<MempoolNetMessage>) {
         let mut command_receiver = self.bus.receiver::<MempoolCommand>().await;
         let response_sender = self.bus.sender::<MempoolResponse>().await;
         loop {
             select! {
                 Some(msg) = message_receiver.recv() => {
                     match msg {
-                        MempoolMessage::NewTx(tx) => {
+                        MempoolNetMessage::NewTx(tx) => {
                             self.pending_txs.push(tx);
                         }
                     }

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -8,11 +8,7 @@ use tracing::info;
 pub mod network; // FIXME(Bertrand): NetMessage should be private
 mod peer;
 
-pub async fn p2p_server(
-    config: SharedConf,
-    mempool: SharedMessageBus,
-    consensus: SharedMessageBus,
-) -> Result<(), Error> {
+pub async fn p2p_server(config: SharedConf, bus: SharedMessageBus) -> Result<(), Error> {
     if config.peers.is_empty() {
         let listener = TcpListener::bind(config.addr()).await?;
         let (addr, port) = config.addr();
@@ -22,8 +18,7 @@ pub async fn p2p_server(
             let (socket, _) = listener.accept().await?;
             let conf = Arc::clone(&config);
 
-            let mempool = mempool.new_handle();
-            let consensus = consensus.new_handle();
+            let bus = bus.new_handle();
 
             tokio::spawn(async move {
                 info!(
@@ -33,7 +28,7 @@ pub async fn p2p_server(
                         .map(|a| a.to_string())
                         .unwrap_or("no address".to_string())
                 );
-                let mut peer_server = peer::Peer::new(socket, mempool, consensus, conf).await?;
+                let mut peer_server = peer::Peer::new(socket, bus, conf).await?;
                 match peer_server.start().await {
                     Ok(_) => info!("Peer thread exited"),
                     Err(e) => info!("Peer thread exited: {}", e),
@@ -45,7 +40,7 @@ pub async fn p2p_server(
         let peer_address = config.peers.first().unwrap();
         info!("Connecting to peer {}", peer_address);
         let stream = peer::Peer::connect(peer_address).await?;
-        let mut peer = peer::Peer::new(stream, mempool, consensus, config).await?;
+        let mut peer = peer::Peer::new(stream, bus, config).await?;
 
         peer.handshake().await?;
         peer.start().await

--- a/src/p2p/network.rs
+++ b/src/p2p/network.rs
@@ -6,6 +6,17 @@ pub struct Version {
     pub id: u16,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetCommand<T> {
+    pub msg: T,
+}
+
+impl<T> NetCommand<T> {
+    pub fn new(msg: T) -> Self {
+        Self { msg }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum NetMessage {
     Version(Version),

--- a/src/p2p/network.rs
+++ b/src/p2p/network.rs
@@ -12,8 +12,6 @@ pub enum NetMessage {
     Verack,
     Ping,
     Pong,
-    // TODO: To replace with an ApiMessage equivalent
-    NewTransaction(Transaction),
     MempoolMessage(MempoolNetMessage),
     ConsensusMessage(ConsensusNetMessage),
 }

--- a/src/p2p/network.rs
+++ b/src/p2p/network.rs
@@ -18,12 +18,12 @@ pub enum NetMessage {
     ConsensusMessage(ConsensusNetMessage),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum MempoolNetMessage {
     NewTx(Transaction),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ConsensusNetMessage {
     CommitBlock(Block),
 }

--- a/src/p2p/network.rs
+++ b/src/p2p/network.rs
@@ -1,4 +1,4 @@
-use crate::model::Transaction;
+use crate::model::{Block, Transaction};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -14,12 +14,18 @@ pub enum NetMessage {
     Pong,
     // TODO: To replace with an ApiMessage equivalent
     NewTransaction(Transaction),
-    MempoolMessage(MempoolMessage),
+    MempoolMessage(MempoolNetMessage),
+    ConsensusMessage(ConsensusNetMessage),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum MempoolMessage {
+pub enum MempoolNetMessage {
     NewTx(Transaction),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ConsensusNetMessage {
+    CommitBlock(Block),
 }
 
 impl NetMessage {

--- a/src/p2p/network.rs
+++ b/src/p2p/network.rs
@@ -7,11 +7,11 @@ pub struct Version {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NetCommand<T> {
+pub struct NetInput<T> {
     pub msg: T,
 }
 
-impl<T> NetCommand<T> {
+impl<T> NetInput<T> {
     pub fn new(msg: T) -> Self {
         Self { msg }
     }

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -14,7 +14,7 @@ use tracing::{debug, info, trace, warn};
 use super::network::{MempoolNetMessage, NetMessage, Version};
 use crate::bus::SharedMessageBus;
 use crate::p2p::network::ConsensusNetMessage;
-use crate::p2p::network::NetCommand;
+use crate::p2p::network::NetInput;
 use crate::utils::conf::SharedConf;
 use crate::utils::logger::LogMe;
 
@@ -80,18 +80,18 @@ impl Peer {
             NetMessage::MempoolMessage(mempool_msg) => {
                 debug!("Received new mempool net message {:?}", mempool_msg);
                 self.bus
-                    .sender::<NetCommand<MempoolNetMessage>>()
+                    .sender::<NetInput<MempoolNetMessage>>()
                     .await
-                    .send(NetCommand::new(mempool_msg))
+                    .send(NetInput::new(mempool_msg))
                     .map(|_| ())
                     .context("Receiving mempool net message")
             }
             NetMessage::ConsensusMessage(consensus_msg) => {
                 debug!("Received new consensus net message {:?}", consensus_msg);
                 self.bus
-                    .sender::<NetCommand<ConsensusNetMessage>>()
+                    .sender::<NetInput<ConsensusNetMessage>>()
                     .await
-                    .send(NetCommand::new(consensus_msg))
+                    .send(NetInput::new(consensus_msg))
                     .map(|_| ())
                     .context("Receiving consensus net message")
             }

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -1,4 +1,10 @@
+use std::time::Duration;
+use std::time::SystemTime;
+
 use anyhow::{anyhow, bail, Context, Error, Result};
+use tokio::select;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt, Interest},
     net::TcpStream,
@@ -7,20 +13,45 @@ use tokio::{
 use tracing::{debug, info, trace, warn};
 
 use super::network::{MempoolMessage, NetMessage, Version};
+use crate::bus::SharedMessageBus;
+use crate::utils::conf::SharedConf;
 use crate::utils::logger::LogMe;
 
-#[derive(Debug)]
+//#[derive(Debug)]
 pub struct Peer {
     stream: TcpStream,
+    bus: SharedMessageBus,
     mempool: UnboundedSender<MempoolMessage>,
+    last_pong: SystemTime,
+    conf: SharedConf,
+
+    // peer internal channel
+    internal_cmd_tx: mpsc::Sender<Cmd>,
+    internal_cmd_rx: mpsc::Receiver<Cmd>,
+}
+
+enum Cmd {
+    Ping,
 }
 
 impl Peer {
     pub async fn new(
         stream: TcpStream,
+        bus: SharedMessageBus,
         mempool: UnboundedSender<MempoolMessage>,
+        conf: SharedConf,
     ) -> Result<Self, Error> {
-        Ok(Peer { stream, mempool })
+        let (cmd_tx, cmd_rx) = mpsc::channel::<Cmd>(100);
+
+        Ok(Peer {
+            stream,
+            bus,
+            mempool,
+            last_pong: SystemTime::now(),
+            conf,
+            internal_cmd_tx: cmd_tx,
+            internal_cmd_rx: cmd_rx,
+        })
     }
 
     async fn handle_net_message(&mut self, msg: NetMessage) -> Result<(), Error> {
@@ -28,11 +59,18 @@ impl Peer {
         match msg {
             NetMessage::Version(v) => {
                 info!("Got peer version {:?}", v);
-                self.send_message(NetMessage::Verack).await
+                self.send_net_message(NetMessage::Verack).await
             }
-            NetMessage::Verack => Ok(()),
-            NetMessage::Ping => todo!(),
-            NetMessage::Pong => todo!(),
+            NetMessage::Verack => self.ping_pong(),
+            NetMessage::Ping => {
+                debug!("Got ping");
+                self.send_net_message(NetMessage::Pong).await
+            }
+            NetMessage::Pong => {
+                debug!("pong");
+                self.last_pong = SystemTime::now();
+                Ok(())
+            }
             NetMessage::MempoolMessage(mempool_msg) => {
                 debug!("Received new mempool message {:?}", mempool_msg);
                 self.mempool
@@ -49,28 +87,82 @@ impl Peer {
         }
     }
 
+    async fn read_stream(stream: &mut TcpStream) -> Result<NetMessage, Error> {
+        let ready = stream
+            .ready(Interest::READABLE | Interest::WRITABLE | Interest::ERROR)
+            .await
+            .log_error("Reading from peer")?;
+
+        if ready.is_error() {
+            bail!("Stream not ready")
+        }
+
+        match stream.read_u32().await {
+            Ok(msg_size) => Self::read_net_message_from_buffer(stream, msg_size).await,
+            Err(e) => Err(anyhow!(e)),
+        }
+    }
+
+    fn ping_pong(&self) -> Result<(), Error> {
+        let tx = self.internal_cmd_tx.clone();
+        let interval = self.conf.p2p.ping_interval;
+        info!("Starting ping pong");
+
+        tokio::spawn(async move {
+            loop {
+                sleep(Duration::from_secs(interval)).await;
+                tx.send(Cmd::Ping).await.ok();
+            }
+        });
+
+        Ok(())
+    }
+
     pub async fn start(&mut self) -> Result<(), Error> {
         loop {
-            let ready = self
-                .stream
-                .ready(Interest::READABLE | Interest::WRITABLE | Interest::ERROR)
-                .await
-                .log_error("Reading from peer")?;
+            let wait_tcp = Self::read_stream(&mut self.stream); //FIXME: make read_stream cancel safe !
+            let wait_cmd = self.internal_cmd_rx.recv();
 
-            if ready.is_error() {
-                bail!("Stream not ready")
-            }
+            // select! waits on multiple concurrent branches, returning when the **first** branch
+            // completes, cancelling the remaining branches.
+            select! {
+                 res = wait_tcp => {
+                    match res {
+                        Ok(message) => match self.handle_net_message(message).await {
+                            Ok(_) => continue,
+                            Err(e) => {
+                                warn!("Error while handling net message: {}", e);
+                            }
+                        },
+                        Err(e) => {
+                            trace!("err: {:?}", e);
+                            return Err(e);
+                        }
+                    }
+                }
+                res = wait_cmd => {
+                    if let Some(cmd) = res {
+                        let cmd_res = match cmd {
+                            Cmd::Ping => {
+                                if let Ok(d) = SystemTime::now().duration_since(self.last_pong) {
+                                    if d > Duration::from_secs(self.conf.p2p.ping_interval * 5) {
+                                        warn!("Peer did not respond to last 5 pings. Disconnecting.");
+                                        return Ok(())
+                                    }
+                                }
+                                debug!("ping");
+                                self.send_net_message(NetMessage::Ping).await
+                            }
+                        };
 
-            let res = match self.stream.read_u32().await {
-                Ok(msg_size) => self.read_next_message(msg_size).await,
-                Err(e) => Err(anyhow!(e)),
-            };
+                        match cmd_res {
+                             Ok(_) => (),
+                             Err(e) => {
+                                warn!("Error while handling cmd: {}", e);
+                            },
+                          }
+                    }
 
-            match res {
-                Ok(_) => continue,
-                Err(e) => {
-                    trace!("err: {:?}", e);
-                    return Err(e);
                 }
             }
         }
@@ -87,11 +179,11 @@ impl Peer {
     }
 
     pub async fn handshake(&mut self) -> Result<(), Error> {
-        self.send_message(NetMessage::Version(Version { id: 1 }))
+        self.send_net_message(NetMessage::Version(Version { id: 1 }))
             .await
     }
 
-    async fn send_message(&mut self, msg: NetMessage) -> Result<(), Error> {
+    async fn send_net_message(&mut self, msg: NetMessage) -> Result<(), Error> {
         let binary = msg.to_binary();
         trace!("SEND {} bytes: {:?}", binary.len(), binary);
         self.stream
@@ -105,7 +197,10 @@ impl Peer {
         Ok(())
     }
 
-    async fn read_next_message(&mut self, msg_size: u32) -> Result<(), Error> {
+    async fn read_net_message_from_buffer(
+        stream: &mut TcpStream,
+        msg_size: u32,
+    ) -> Result<NetMessage, Error> {
         if msg_size == 0 {
             bail!("Connection closed by remote (1)")
         }
@@ -114,24 +209,16 @@ impl Peer {
         let mut buf = vec![0; msg_size as usize];
         trace!("buf before: {:?}", buf);
 
-        let data = self.stream.read_exact(&mut buf).await?;
+        let data = stream.read_exact(&mut buf).await?;
         if data == 0 {
             bail!("Connection closed by remote (2)")
         }
 
         trace!("got buff {:?}", buf);
-        let message = Self::handle_read(&buf).await;
-
-        match message {
-            Ok(msg) => self.handle_net_message(msg).await,
-            Err(e) => {
-                warn!("Error while handling net message: {}", e);
-                Ok(())
-            }
-        }
+        Self::parse_net_message(&buf).await
     }
 
-    async fn handle_read(buf: &[u8]) -> Result<NetMessage, Error> {
+    async fn parse_net_message(buf: &[u8]) -> Result<NetMessage, Error> {
         bincode::deserialize::<NetMessage>(buf).map_err(|_| anyhow!("Could not decode NetMessage"))
     }
 }

--- a/src/utils/conf.rs
+++ b/src/utils/conf.rs
@@ -9,6 +9,10 @@ pub struct Storage {
     pub interval: u64,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct P2pConf {
+    pub ping_interval: u64,
+}
 pub type SharedConf = Arc<Conf>;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -18,6 +22,7 @@ pub struct Conf {
     pub peers: Vec<String>,
     pub storage: Storage,
     rest: String,
+    pub p2p: P2pConf,
 }
 
 impl Conf {


### PR DESCRIPTION
- 2 way communication between Peer <> Consensus & Peer <> Mempool :

`Mempool ----- MempoolNetMessage(msg) ----->  Peer --> MempoolCommand::HandleNetMessage(msg) ----> Mempool`
`Consensus --- ConsensusNetMessage(msg) --->  Peer --> ConsensusCommand::HandleNetMessage(msg) --> Consensus`


- Add a ping-pong between peers because I had it on a branch and I took some work I did there to start this work bu I can remove this ping pong if it's confusing !