### PR TITLE
Feat: consensus view changes

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -754,7 +754,7 @@ impl Consensus {
         Ok(())
     }
 
-    fn on_timeout(&mut self, msg: &SignedWithKey<ConsensusNetMessage>, view: &View, slot: &Slot, consensus_proposal_hash: &ConsensusProposalHash) -> Result<()> {
+    fn on_timeout(&mut self, received_msg: &SignedWithKey<ConsensusNetMessage>, view: &View, slot: &Slot, received_consensus_proposal_hash: &ConsensusProposalHash) -> Result<()> {
         // Only timeout if it is in consensus
 
         debug!(
@@ -774,7 +774,7 @@ impl Consensus {
             {
                 return self.send_net_message(
                     // TODO ? Create a simple struct with unique validator
-                    msg.validators.first().context("No validator found in message! Can't send a commit to anyone")?.clone(),
+                    received_msg.validators.first().context("No validator found in message! Can't send a commit to anyone")?.clone(),
                     ConsensusNetMessage::Commit(
                     consensus_proposal_hash.clone(),
                     commit_qc.clone(),
@@ -795,7 +795,7 @@ impl Consensus {
 
 
             // Insert timeout request and if already present notify
-            if !timeout_requests_of_same_view.insert(msg.clone()) {
+            if !timeout_requests_of_same_view.insert(received_msg.clone()) {
                 // self.metrics.timeout_request("already_processed");
                 info!("Timeout has already been processed");
                 return Ok(());
@@ -809,7 +809,7 @@ impl Consensus {
                 return self.broadcast_net_message(ConsensusNetMessage::Timeout(
                     *slot,
                     *view,
-                    consensus_proposal_hash.clone(),
+                    received_consensus_proposal_hash.clone(),
                 ));
             }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -112,10 +112,10 @@ impl ConsensusTimeoutState {
     pub fn schedule_next(&mut self, timestamp: u64) -> Result<()> {
         match self {
             ConsensusTimeoutState::Inactive => {
-                info!("Scheduling timeout");
+                info!("⏲️ Scheduling timeout");
             }
             ConsensusTimeoutState::Scheduled { .. } => {
-                info!("Rescheduling timeout");
+                info!("⏲️ Rescheduling timeout");
             }
         }
         *self = ConsensusTimeoutState::Scheduled {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -848,12 +848,8 @@ impl Consensus {
                     validators: timeout_signed_aggregation.validators.clone(),
                 };
 
-                self.store
-                    .bft_round_state
-                    .timeout_certificates
-                    .entry(self.store.bft_round_state.slot)
-                    .or_default()
-                    .insert(self.store.bft_round_state.view, timeout_certificate.clone());
+                self.on_timeout_certificate(view, slot, &timeout_certificate)
+                    .context("Handling timeout certificate")?;
 
                 // Broadcast the Timeout Certificate to all validators
                 self.broadcast_net_message(ConsensusNetMessage::TimeoutCertificate(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1520,7 +1520,7 @@ impl Consensus {
                     if get_current_timestamp() >= *timestamp =>
                 {
                     // Trigger state transition to mutiny
-                    info!("Trigger timeout");
+                    info!("⏰ Trigger timeout for slot {} and view {}", self.bft_round_state.slot, self.bft_round_state.view);
                     self.broadcast_net_message(ConsensusNetMessage::Timeout(
                         self.bft_round_state.slot,
                         self.bft_round_state.view,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -524,7 +524,7 @@ impl Consensus {
         let mut ticket: Option<Ticket> = ticket;
 
         // If no ticket was provided, we try to craft one from locally stored certificates
-        if ticket == None {
+        if ticket.is_none() {
             // Verifies that previous slot received a *Commit* Quorum Certificate.
             match self
                 .bft_round_state

--- a/src/consensus/module.rs
+++ b/src/consensus/module.rs
@@ -49,6 +49,7 @@ impl Module for Consensus {
 
     fn run(&mut self) -> impl futures::Future<Output = Result<()>> + Send {
         _ = self.start_master(self.config.clone());
+        _ = self.start_timeout_checker(self.config.clone());
         self.start()
     }
 }

--- a/src/consensus/module.rs
+++ b/src/consensus/module.rs
@@ -49,7 +49,6 @@ impl Module for Consensus {
 
     fn run(&mut self) -> impl futures::Future<Output = Result<()>> + Send {
         _ = self.start_master(self.config.clone());
-        _ = self.start_timeout_checker(self.config.clone());
         self.start()
     }
 }

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -26,8 +26,6 @@ impl Hashable<ConsensusProposalHash> for ConsensusProposal {
         let mut hasher = Sha3_256::new();
         _ = write!(hasher, "{}", self.slot);
         _ = write!(hasher, "{}", self.view);
-        _ = write!(hasher, "{:?}", self.previous_consensus_proposal_hash);
-        _ = write!(hasher, "{:?}", self.previous_commit_quorum_certificate);
         _ = write!(hasher, "{}", self.block);
         return ConsensusProposalHash(hasher.finalize().as_slice().to_owned());
     }
@@ -41,12 +39,10 @@ impl Display for ConsensusProposal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Hash: {}, Slot: {}, View: {}, Previous hash: {}, Previous commit hash: {}, Block: {}",
+            "Hash: {}, Slot: {}, View: {}, Block: {}",
             self.hash(),
             self.slot,
             self.view,
-            self.previous_consensus_proposal_hash,
-            self.previous_commit_quorum_certificate.hash(),
             self.block
         )
     }


### PR DESCRIPTION
Introduction des view changes dans le consensus
- Chaque replica démarre un timer au démarrage du slot (au commit du slot `s - 1`).
- Lorsque le timer se déclenche, il broadcast un message de timeout sur le slot + view donné. Si un replica reçoit `f + 1` timeout messages, il brodcast à son tour même si le timer n'a pas été trigger (il se joint à la mutinerie). Quand un replica obtient `2f+1` timeouts il crée un certificat (TC = Timeout Certificate) qu'il broadcast. Avec ce certificat on peut changer de view et repartir de 0 sur le prochain workflow prepare/commit avec un autre leader.
Pour démarrer un round (avec un prepare), il faut désormais un ticket qui est soit le commit certificate du slot `s-1`, si on est en view `v = 0`, soit le Timeout Certificate du slot `s` et de la view `v > 0`

Exemple pour tester, le leader ne démarre pas un nouveau slot après un commit

Update:
les consensus proposals ne contiennent plus les previous commit, ils sont ajoutés au niveau des messages Prepare. Ils sont passés explicitement au moment du démarrage d'un nouveau slot. Si aucun ticket n'est fourni, comme avant on essaye de retrouver localement le commit précédent.