### PR TITLE
Implement view changes

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -779,9 +779,6 @@ impl Consensus {
                 return Ok(());
             }
             StateTag::Follower | StateTag::Leader => {}
-            _ => {
-                bail!("Prepare message received while not follower or leader");
-            }
         }
 
         // Process the ticket

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -2037,8 +2037,6 @@ mod test {
         let timeout_certificate3 = node3.assert_broadcast("Timeout Certificate 3");
         node4.assert_broadcast("Timeout Certificate 4");
 
-        node4.assert_broadcast("Timeout Certificate 4");
-
         node3.start_round().await;
 
         // Slot 2 view 1 (following a timeout round)

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -354,7 +354,7 @@ impl Consensus {
                         .bond(new_v.pubkey.clone())?;
                 }
             }
-            Some(Ticket::TimeoutQC(qc)) => {
+            Some(Ticket::TimeoutQC(_)) => {
                 self.bft_round_state.consensus_proposal.view += 1;
             }
             els => {
@@ -797,10 +797,10 @@ impl Consensus {
                 }
             }
             Ticket::TimeoutQC(timeout_qc) => {
-                if !self
+                if self
                     .try_process_timeout_qc(timeout_qc)
                     .log_error("Processing Timeout ticket")
-                    .is_ok()
+                    .is_err()
                 {
                     bail!("Invalid timeout ticket");
                 }
@@ -1298,7 +1298,7 @@ impl Consensus {
                 received_consensus_proposal_hash.clone(),
                 self.next_leader()?,
             ),
-            &received_timeout_certificate,
+            received_timeout_certificate,
         )
         .context(format!(
             "Verifying timeout certificate for (slot: {}, view: {})",

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -280,29 +280,6 @@ pub struct Consensus {
 }
 
 impl Consensus {
-    /// Add a validator with the default stake to our consensus.
-    /// This is trusted because it's out of the usual consensus process,
-    /// either at genesis or when fast-forwarding.
-    pub fn add_trusted_validator(
-        &mut self,
-        pubkey: &ValidatorPublicKey,
-        stake: Stake,
-    ) -> Result<()> {
-        self.bft_round_state
-            .staking
-            .add_staker(Staker {
-                pubkey: pubkey.clone(),
-                stake,
-            })
-            .context("cannot add trusted staker")?;
-        self.bft_round_state
-            .staking
-            .bond(pubkey.clone())
-            .context("cannot bond trusted validator")?;
-        info!("🎉 Trusted validator added: {}", pubkey);
-        Ok(())
-    }
-
     /// Reset bft_round_state for the next round of consensus.
     fn finish_round(&mut self, ticket: Option<Ticket>) -> Result<(), Error> {
         match self.bft_round_state.state_tag {
@@ -750,12 +727,6 @@ impl Consensus {
         // - we haven't, so we process it right away
         // - the CQC is invalid and we just ignore it.
         if let Some(qc) = &self.bft_round_state.follower.buffered_quorum_certificate {
-            // info!("Buffered qc: {:?}", qc);
-            // info!("Timeout qc: {:?}", timeout_qc.clone());
-            // if qc == &timeout_qc {
-            //     return true;
-            // }
-
             return qc == &timeout_qc;
         }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1146,7 +1146,8 @@ impl Consensus {
     ) -> Result<()> {
         // Leader does not care about timeouts, his role is to rebroadcast messages to generate a commit
         if matches!(self.bft_round_state.state_tag, StateTag::Leader) {
-            bail!("Leader does not process timeout messages")
+            debug!("Leader does not process timeout messages");
+            return Ok(());
         }
 
         // Only timeout if it is in consensus

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -750,6 +750,12 @@ impl Consensus {
         // - we haven't, so we process it right away
         // - the CQC is invalid and we just ignore it.
         if let Some(qc) = &self.bft_round_state.follower.buffered_quorum_certificate {
+            // info!("Buffered qc: {:?}", qc);
+            // info!("Timeout qc: {:?}", timeout_qc.clone());
+            // if qc == &timeout_qc {
+            //     return true;
+            // }
+
             return qc == &timeout_qc;
         }
 
@@ -759,10 +765,14 @@ impl Consensus {
     }
 
     fn try_process_timeout_qc(&mut self, timeout_qc: QuorumCertificate) -> Result<()> {
-        let mut matching_proposal = self.bft_round_state.consensus_proposal.clone();
-        matching_proposal.view -= 1;
+        info!(
+            "Trying to process timeout Certificate against consensus proposal slot: {}, view: {}",
+            self.bft_round_state.consensus_proposal.slot,
+            self.bft_round_state.consensus_proposal.view
+        );
+
         self.verify_quorum_certificate(
-            ConsensusNetMessage::Timeout(matching_proposal.hash()),
+            ConsensusNetMessage::Timeout(self.bft_round_state.consensus_proposal.hash()),
             &timeout_qc,
         )
         .context("Verifying Timeout Ticket")?;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail, Context, Error, Result};
 use bincode::{Decode, Encode};
 use metrics::ConsensusMetrics;
 use serde::{Deserialize, Serialize};
-use staking::{Stake, Staker, Staking, MIN_STAKE};
+use staking::{Staker, Staking, MIN_STAKE};
 use std::{
     collections::{HashMap, HashSet},
     default::Default,
@@ -15,7 +15,7 @@ use tokio::{
     sync::broadcast,
     time::{interval, sleep},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     bus::{
@@ -1226,7 +1226,10 @@ impl Consensus {
             len += 1;
             voting_power += self.get_own_voting_power();
 
-            self.bft_round_state.follower.timeout_state.cancel();
+            self.bft_round_state
+                .follower
+                .timeout_state
+                .schedule_next(get_current_timestamp());
         }
 
         // Create TC if applicable
@@ -1256,7 +1259,10 @@ impl Consensus {
                 received_consensus_proposal_hash.clone(),
             ))?;
 
-            self.bft_round_state.follower.timeout_state.cancel();
+            self.bft_round_state
+                .follower
+                .timeout_state
+                .schedule_next(get_current_timestamp());
         }
 
         Ok(())

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -111,11 +111,11 @@ impl Display for ConsensusNetMessage {
             ConsensusNetMessage::ValidatorCandidacy(candidacy) => {
                 write!(f, "{} (CP hash {})", enum_variant, candidacy)
             }
-            ConsensusNetMessage::Timeout(view, hash) => {
-                write!(f, "{} - View {} - CP hash {}", enum_variant, view, hash)
+            ConsensusNetMessage::Timeout(hash) => {
+                write!(f, "{} - CP hash {}", enum_variant, hash)
             }
-            ConsensusNetMessage::TimeoutCertificate(view, cert, hash) => {
-                _ = writeln!(f, "{} - View {} - CP hash: {}", enum_variant, view, hash);
+            ConsensusNetMessage::TimeoutCertificate(cert, hash) => {
+                _ = writeln!(f, "{} - CP hash: {}", enum_variant, hash);
                 _ = write!(f, "Certificate {} with validators ", cert.signature);
                 for v in cert.validators.iter() {
                     _ = write!(f, "{},", v);

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -107,8 +107,20 @@ impl Display for ConsensusNetMessage {
                 }
                 write!(f, "")
             }
+
             ConsensusNetMessage::ValidatorCandidacy(candidacy) => {
                 write!(f, "{} (CP hash {})", enum_variant, candidacy)
+            }
+            ConsensusNetMessage::Timeout(view, hash) => {
+                write!(f, "{} - View {} - CP hash {}", enum_variant, view, hash)
+            }
+            ConsensusNetMessage::TimeoutCertificate(view, cert, hash) => {
+                _ = writeln!(f, "{} - View {} - CP hash: {}", enum_variant, view, hash);
+                _ = write!(f, "Certificate {} with validators ", cert.signature);
+                for v in cert.validators.iter() {
+                    _ = write!(f, "{},", v);
+                }
+                write!(f, "")
             }
         }
     }

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -111,8 +111,12 @@ impl Display for ConsensusNetMessage {
             ConsensusNetMessage::ValidatorCandidacy(candidacy) => {
                 write!(f, "{} (CP hash {})", enum_variant, candidacy)
             }
-            ConsensusNetMessage::Timeout(hash) => {
-                write!(f, "{} - CP hash {}", enum_variant, hash)
+            ConsensusNetMessage::Timeout(hash, next_leader) => {
+                write!(
+                    f,
+                    "{} - CP hash {} - Next Leader {}",
+                    enum_variant, hash, next_leader
+                )
             }
             ConsensusNetMessage::TimeoutCertificate(cert, hash) => {
                 _ = writeln!(f, "{} - CP hash: {}", enum_variant, hash);

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -53,13 +53,32 @@ pub struct ValidatorSignature {
     pub validator: ValidatorPublicKey,
 }
 
-#[derive(
-    Debug, Serialize, Deserialize, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash,
-)]
+#[derive(Debug, Serialize, Deserialize, Clone, bincode::Encode, bincode::Decode, Hash)]
 pub struct AggregateSignature {
     pub signature: Signature,
     pub validators: Vec<ValidatorPublicKey>,
 }
+
+impl PartialEq for AggregateSignature {
+    fn eq(&self, other: &Self) -> bool {
+        // Vérifie que les signatures sont égales
+        if self.signature != other.signature {
+            return false;
+        }
+
+        // Vérifie que les validateurs sont égaux, indépendamment de l'ordre
+        let mut self_validators = self.validators.clone();
+        let mut other_validators = other.validators.clone();
+
+        // Trie les vecteurs pour que l'ordre n'importe pas
+        self_validators.sort();
+        other_validators.sort();
+
+        self_validators == other_validators
+    }
+}
+
+impl Eq for AggregateSignature {}
 
 impl BlstCrypto {
     pub fn new(validator_name: String) -> Self {

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -53,32 +53,13 @@ pub struct ValidatorSignature {
     pub validator: ValidatorPublicKey,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, bincode::Encode, bincode::Decode, Hash)]
+#[derive(
+    Debug, Serialize, Deserialize, Clone, bincode::Encode, bincode::Decode, PartialEq, Eq, Hash,
+)]
 pub struct AggregateSignature {
     pub signature: Signature,
     pub validators: Vec<ValidatorPublicKey>,
 }
-
-impl PartialEq for AggregateSignature {
-    fn eq(&self, other: &Self) -> bool {
-        // Vérifie que les signatures sont égales
-        if self.signature != other.signature {
-            return false;
-        }
-
-        // Vérifie que les validateurs sont égaux, indépendamment de l'ordre
-        let mut self_validators = self.validators.clone();
-        let mut other_validators = other.validators.clone();
-
-        // Trie les vecteurs pour que l'ordre n'importe pas
-        self_validators.sort();
-        other_validators.sort();
-
-        self_validators == other_validators
-    }
-}
-
-impl Eq for AggregateSignature {}
 
 impl BlstCrypto {
     pub fn new(validator_name: String) -> Self {

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -29,11 +29,25 @@ services:
     privileged: true
     environment:
       - HYLE_ID=hyle3
-      - HYLE_PEERS=localhost:1001
+      - HYLE_PEERS=localhost:1001,localhost:1002
       - HYLE_REST=localhost:4003
       - HYLE_HOST=localhost:1003
       - RUST_LOG=debug
       - HYLE_DA_ADDRESS=localhost:4143
+      - HYLE_CONSENSUS__SLOT_DURATION=3000
+    network_mode: host
+    depends_on:
+      - hyle1
+  hyle4:
+    build: ./..
+    privileged: true
+    environment:
+      - HYLE_ID=hyle4
+      - HYLE_PEERS=localhost:1001,localhost:1002,localhost:1003
+      - HYLE_REST=localhost:4004
+      - HYLE_HOST=localhost:1004
+      - RUST_LOG=debug
+      - HYLE_DA_ADDRESS=localhost:4144
       - HYLE_CONSENSUS__SLOT_DURATION=3000
     network_mode: host
     depends_on:
@@ -52,6 +66,7 @@ services:
       - hyle1
       - hyle2
       - hyle3
+      - hyle4
 
   grafana:
     image: grafana/grafana:latest


### PR DESCRIPTION
Introduction des view changes dans le consensus

Principe:
- Le but d'un timeout/view change est de changer de leader si celui choisi est byzantin (s'il ne va pas bout et ne propose pas de commit).  L'idée est donc de garder la même consensus proposal (slot s), tout en incrémentant la view pour passer au leader suivant dans la liste.
- Le leader ne prend pas part au timeout round (son but est de commit, il devrait retry ses messages pour arriver à commit mais en aucun cas déclencher un timeout). On peut voir le workflow de timeout comme une protection des followers contre le leader s'il ne fait pas correctement son boulot.
- Dès que le next leader reçoit un timeout certificate du réseau, qui atteste que c'est bien à lui de prendre la main, il l'utilise comme ticket pour émettre un Prepare avec la consensus proposal du slot s.

Chaque replica démarre un timer au démarrage du slot (au commit du slot s - 1).
Lorsque le timer se déclenche, il broadcast un message de timeout sur le slot + view donné.
- Si un replica reçoit f + 1 timeout messages, il brodcast à son tour même si le timer n'a pas été trigger (il se joint à la mutinerie).
- Quand un replica obtient 2f+1 timeouts il crée un certificat (TC = Timeout Certificate) qu'il broadcast. Avec ce certificat on peut changer de view et repartir de 0 sur le prochain workflow prepare/commit avec un autre leader.
Pour démarrer un round (avec un prepare), il faut désormais un ticket qui est soit le commit certificate du slot s-1, si on est en view v = 0, soit le Timeout Certificate du slot s et de la view v > 0

Exemple pour tester, le leader ne démarre pas un nouveau slot + view % 5 == 0

Next PR
- un e2e
- un state tag pour éviter de join mutiny plusieurs fois (en fait c'est bon je checke déjà que le noeud a sa propre requête de timeout dans son propre cache)
- plus de tests d'intégration

