### PR TITLE
mempool refactoring based on communal code review

### DIFF
--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -178,11 +178,7 @@ impl Mempool {
                 new_bonded_validators,
                 validators,
             } => {
-                debug!(
-                    "✂️ Received CommitCut ({:?} cut, {} pending txs)",
-                    cut,
-                    self.storage.pending_txs.len()
-                );
+                debug!("✂️ Received CommitCut ({:?} cut)", cut);
                 self.validators = validators;
                 let txs = self.storage.collect_lanes(cut);
                 if let Err(e) = self

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -4,7 +4,7 @@ use crate::{
     bus::{bus_client, command_response::Query, BusMessage, SharedMessageBus},
     consensus::ConsensusEvent,
     handle_messages,
-    mempool::storage::{Car, DataProposal, InMemoryStorage},
+    mempool::storage::{Car, DataProposal, Storage},
     model::{
         Hashable, SharedRunContext, Transaction, TransactionData, ValidatorPublicKey,
         VerifiedProofTransaction,
@@ -48,7 +48,7 @@ pub struct Mempool {
     bus: MempoolBusClient,
     crypto: SharedBlstCrypto,
     metrics: MempoolMetrics,
-    storage: InMemoryStorage,
+    storage: Storage,
     validators: Vec<ValidatorPublicKey>,
     node_state: NodeState,
 }
@@ -100,7 +100,7 @@ impl Module for Mempool {
             bus,
             metrics,
             crypto: Arc::clone(&ctx.node.crypto),
-            storage: InMemoryStorage::new(ctx.node.crypto.validator_pubkey().clone()),
+            storage: Storage::new(ctx.node.crypto.validator_pubkey().clone()),
             validators: vec![],
             node_state,
         })
@@ -534,7 +534,7 @@ mod tests {
         pub async fn new(name: &str) -> Self {
             let crypto = BlstCrypto::new(name.into());
             let shared_bus = SharedMessageBus::new(BusMetrics::global("global".to_string()));
-            let storage = InMemoryStorage::new(crypto.validator_pubkey().clone());
+            let storage = Storage::new(crypto.validator_pubkey().clone());
             let validators = vec![crypto.validator_pubkey().clone()];
 
             let out_receiver = get_receiver::<OutboundMessage>(&shared_bus).await;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -148,8 +148,7 @@ impl Mempool {
         // 1: create new DataProposal with pending txs and broadcast it as a DataProposal.
         // 2: Save DataProposal. It is not yet a Car (since PoA is not reached)
         // 3: Go through all pending DataProposal (of own lane) that have not reach PoA, and send them to make them Cars
-        let poa = self.storage.tip_poa();
-        self.broadcast_data_proposal_if_any(poa);
+        self.broadcast_data_proposal_if_any();
         if let Some(car) = self.storage.lane.current() {
             // No PoA means we rebroadcast the DataProposal for non present voters
             let only_for = HashSet::from_iter(
@@ -359,8 +358,8 @@ impl Mempool {
         Ok(())
     }
 
-    fn broadcast_data_proposal_if_any(&mut self, poa: Option<Vec<ValidatorPublicKey>>) {
-        if let Some(data_proposal) = self.storage.new_data_proposal(poa) {
+    fn broadcast_data_proposal_if_any(&mut self) {
+        if let Some(data_proposal) = self.storage.new_data_proposal() {
             debug!(
                 "🚗 Broadcast DataProposal {} ({} validators, {} txs)",
                 data_proposal.id,
@@ -402,7 +401,7 @@ impl Mempool {
         self.storage.on_new_tx(tx);
         if self.storage.genesis() {
             // Genesis create and broadcast a new DataProposal
-            self.broadcast_data_proposal_if_any(None);
+            self.broadcast_data_proposal_if_any();
         }
         self.metrics
             .snapshot_pending_tx(self.storage.pending_txs.len());

--- a/src/mempool/metrics.rs
+++ b/src/mempool/metrics.rs
@@ -45,11 +45,11 @@ impl MempoolMetrics {
     pub fn add_batch(&self) {
         self.batches.add(1, &[])
     }
-    pub fn add_broadcasted_car_proposal(&self, kind: String) {
+    pub fn add_broadcasted_data_proposal(&self, kind: String) {
         self.broadcasted_data_proposal
             .add(1, &[KeyValue::new("kind", kind)])
     }
-    pub fn add_broadcasted_car_proposal_only_for(&self, kind: String) {
+    pub fn add_broadcasted_data_proposal_only_for(&self, kind: String) {
         self.broadcasted_data_proposal_only_for
             .add(1, &[KeyValue::new("kind", kind)])
     }

--- a/src/mempool/storage.rs
+++ b/src/mempool/storage.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use bincode::{BorrowDecode, Decode, Encode};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 use std::{
@@ -426,6 +426,12 @@ impl Hashable<CarHash> for Car {
     }
 }
 
+impl Display for Car {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.hash(),)
+    }
+}
+
 #[derive(Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Poa(pub BTreeSet<ValidatorPublicKey>);
 
@@ -439,51 +445,6 @@ impl std::ops::Deref for Poa {
 impl std::ops::DerefMut for Poa {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
-    }
-}
-
-impl Encode for Poa {
-    fn encode<E: bincode::enc::Encoder>(
-        &self,
-        encoder: &mut E,
-    ) -> std::result::Result<(), bincode::error::EncodeError> {
-        self.len().encode(encoder)?;
-        for pubkey in self.iter() {
-            pubkey.encode(encoder)?;
-        }
-        Ok(())
-    }
-}
-
-impl<'de> BorrowDecode<'de> for Poa {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
-        decoder: &mut D,
-    ) -> std::result::Result<Self, bincode::error::DecodeError> {
-        let len = usize::borrow_decode(decoder)?;
-        let mut bts = BTreeSet::new();
-        for _ in 0..len {
-            bts.insert(ValidatorPublicKey::borrow_decode(decoder)?);
-        }
-        Ok(Poa(bts))
-    }
-}
-
-impl Decode for Poa {
-    fn decode<D: bincode::de::Decoder>(
-        decoder: &mut D,
-    ) -> std::result::Result<Self, bincode::error::DecodeError> {
-        let len = usize::decode(decoder)?;
-        let mut bts = BTreeSet::new();
-        for _ in 0..len {
-            bts.insert(ValidatorPublicKey::decode(decoder)?);
-        }
-        Ok(Poa(bts))
-    }
-}
-
-impl Display for Car {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.hash(),)
     }
 }
 

--- a/src/mempool/storage.rs
+++ b/src/mempool/storage.rs
@@ -3,7 +3,7 @@ use derive_more::derive::Display;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     fmt::Display,
     io::Write,
     vec,
@@ -66,7 +66,7 @@ impl Storage {
             pending_txs: vec![],
             lane: Lane {
                 cars: vec![],
-                waiting: HashSet::new(),
+                waiting: vec![],
             },
             other_lanes: HashMap::new(),
         }
@@ -149,7 +149,7 @@ impl Storage {
                 .entry(validator.clone())
                 .or_default()
                 .waiting
-                .insert(data_proposal.clone());
+                .push(data_proposal.clone());
             return DataProposalVerdict::Wait(data_proposal.parent);
         }
         // optimistic_node_state is here to handle the case where a contract is registered in a car that is not yet committed.
@@ -334,7 +334,7 @@ impl Storage {
     ) -> Vec<DataProposal> {
         match self.other_lanes.get_mut(validator) {
             Some(sl) => {
-                let mut wp = sl.waiting.drain().collect::<Vec<_>>();
+                let mut wp = sl.waiting.drain(0..).collect::<Vec<_>>();
                 wp.sort_by_key(|wp| wp.id);
                 wp
             }
@@ -607,7 +607,7 @@ impl Display for Car {
 #[derive(Default, Debug, Clone)]
 pub struct Lane {
     cars: Vec<Car>,
-    waiting: HashSet<DataProposal>,
+    waiting: Vec<DataProposal>,
 }
 
 impl Display for Lane {

--- a/src/mempool/storage.rs
+++ b/src/mempool/storage.rs
@@ -40,14 +40,14 @@ fn prepare_cut(cut: &mut Cut, validator: &ValidatorPublicKey, lane: &Lane) {
 }
 
 #[derive(Debug, Clone)]
-pub struct InMemoryStorage {
+pub struct Storage {
     pub id: ValidatorPublicKey,
     pub pending_txs: Vec<Transaction>,
     pub lane: Lane,
     pub other_lanes: HashMap<ValidatorPublicKey, Lane>,
 }
 
-impl Display for InMemoryStorage {
+impl Display for Storage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Replica {}", self.id)?;
         write!(f, "\nLane {}", self.lane)?;
@@ -59,9 +59,9 @@ impl Display for InMemoryStorage {
     }
 }
 
-impl InMemoryStorage {
-    pub fn new(id: ValidatorPublicKey) -> InMemoryStorage {
-        InMemoryStorage {
+impl Storage {
+    pub fn new(id: ValidatorPublicKey) -> Storage {
+        Storage {
             id,
             pending_txs: vec![],
             lane: Lane {
@@ -717,7 +717,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     use crate::{
-        mempool::storage::{Car, CarId, DataProposal, InMemoryStorage, Poa, ProposalVerdict},
+        mempool::storage::{Car, CarId, DataProposal, Poa, ProposalVerdict, Storage},
         model::{
             Blob, BlobData, BlobReference, BlobTransaction, ContractName, ProofData,
             ProofTransaction, RegisterContractTransaction, Transaction, TransactionData,
@@ -794,7 +794,7 @@ mod tests {
     fn test_workflow() {
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
 
         store.other_lane_add_proposal(
             &pubkey2,
@@ -873,7 +873,7 @@ mod tests {
         let pubkey1 = ValidatorPublicKey(vec![1]);
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
 
         store.add_new_tx(make_blob_tx("test1"));
         store.add_new_tx(make_blob_tx("test2"));
@@ -919,7 +919,7 @@ mod tests {
     fn test_update_lane_with_unverified_proof_transaction() {
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
         let node_state = NodeState::default();
 
         let contract_name = ContractName("test".to_string());
@@ -945,7 +945,7 @@ mod tests {
     fn test_update_lane_with_verified_proof_transaction() {
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
         let node_state = NodeState::default();
 
         let contract_name = ContractName("test".to_string());
@@ -977,7 +977,7 @@ mod tests {
     fn test_new_data_proposal_with_register_tx_in_previous_uncommitted_car() {
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
         let node_state = NodeState::default();
 
         let contract_name = ContractName("test".to_string());
@@ -1013,7 +1013,7 @@ mod tests {
     fn test_register_contract_and_proof_tx_in_same_car() {
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
         let node_state = NodeState::default();
 
         let contract_name = ContractName("test".to_string());
@@ -1038,7 +1038,7 @@ mod tests {
     fn test_register_contract_and_proof_tx_in_same_car_wrong_order() {
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
         let node_state = NodeState::default();
 
         let contract_name = ContractName("test".to_string());
@@ -1063,7 +1063,7 @@ mod tests {
     fn test_update_lanes_after_commit() {
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
         let node_state = NodeState::default();
 
         let data_proposal1 = DataProposal {
@@ -1138,7 +1138,7 @@ mod tests {
         let pubkey1 = ValidatorPublicKey(vec![1]);
         let pubkey2 = ValidatorPublicKey(vec![2]);
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
 
         store.other_lane_add_missing_cars(
             &pubkey2,
@@ -1173,7 +1173,7 @@ mod tests {
     #[test_log::test]
     fn test_missing_cars() {
         let pubkey3 = ValidatorPublicKey(vec![3]);
-        let mut store = InMemoryStorage::new(pubkey3.clone());
+        let mut store = Storage::new(pubkey3.clone());
 
         store.add_new_car_to_lane(vec![make_blob_tx("test_local")]);
         store.add_new_car_to_lane(vec![make_blob_tx("test_local2")]);

--- a/src/mempool/storage.rs
+++ b/src/mempool/storage.rs
@@ -65,12 +65,6 @@ impl Storage {
         }
     }
 
-    pub fn tip_poa(&self) -> Option<Vec<ValidatorPublicKey>> {
-        self.lane
-            .current()
-            .map(|car| car.poa.iter().cloned().collect())
-    }
-
     pub fn new_cut(&mut self, validators: &[ValidatorPublicKey]) -> Cut {
         // For each validator, we get the last validated car and put it in the cut
         let mut cut: Cut = vec![];
@@ -383,14 +377,15 @@ impl Storage {
         next_id
     }
 
-    pub fn new_data_proposal(
-        &mut self,
-        parent_poa: Option<Vec<ValidatorPublicKey>>,
-    ) -> Option<DataProposal> {
+    pub fn new_data_proposal(&mut self) -> Option<DataProposal> {
         let pending_txs = std::mem::take(&mut self.pending_txs);
         if pending_txs.is_empty() {
             return None;
         }
+        let parent_poa = self
+            .lane
+            .current()
+            .map(|car| car.poa.0.clone().into_iter().collect());
         let parent_hash = self.lane.current_hash();
         let tip_id = self.add_new_car_to_lane(pending_txs.clone());
         Some(DataProposal {


### PR DESCRIPTION
- renamed CarProposal -> DataProposal
- renamed Vote -> DataVote
- removed CarId
- Cars refers to their parent via a hash
- removed Poa from Car, a Car now contains a parent_hash and the txs
- add Poa in Lane
- DataProposal contains a Car and a parent Poa
- Storage now has the current DataProposal which will become a Car later
- which means Lanes now contain only Cars