### PR TITLE
:sparkles:  Graceful shutdown

### DIFF
--- a/src/autobahn_testing.rs
+++ b/src/autobahn_testing.rs
@@ -153,6 +153,8 @@ pub mod test {
     }
 
     use crate::bus::command_response::Query;
+    use crate::bus::dont_use_this::get_receiver;
+    use crate::bus::metrics::BusMetrics;
     use crate::bus::{bus_client, SharedMessageBus};
     use crate::consensus::test::ConsensusTestCtx;
     use crate::consensus::{ConsensusEvent, ConsensusNetMessage};

--- a/src/bin/indexer.rs
+++ b/src/bin/indexer.rs
@@ -96,23 +96,23 @@ async fn main() -> Result<()> {
         })
         .await?;
 
-    let (running_modules, abort) = handler.start_modules()?;
+    let (_, running_modules) = handler.start_modules()?;
 
     #[cfg(unix)]
     {
         use tokio::signal::unix;
         let mut terminate = unix::signal(unix::SignalKind::interrupt())?;
         tokio::select! {
-            Err(e) = running_modules => {
+            (Err(e),_,_) = running_modules => {
                 error!("Error running modules: {:?}", e);
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Ctrl-C received, shutting down");
-                abort();
+                // abort();
             }
             _ = terminate.recv() =>  {
                 info!("SIGTERM received, shutting down");
-                abort();
+                // abort();
             }
         }
     }
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Ctrl-C received, shutting down");
-                abort();
+                // abort();
             }
         }
     }

--- a/src/bin/indexer.rs
+++ b/src/bin/indexer.rs
@@ -106,30 +106,27 @@ async fn main() -> Result<()> {
         tokio::select! {
             Err(e) = handler.start_modules() => {
                 error!("Error running modules: {:?}", e);
-                _ = handler.shutdown_modules(Duration::from_secs(3));
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Ctrl-C received, shutting down");
-                _ = handler.shutdown_modules(Duration::from_secs(3));
             }
             _ = terminate.recv() =>  {
                 info!("SIGTERM received, shutting down");
-                _ = handler.shutdown_modules(Duration::from_secs(3));
             }
         }
+        _ = handler.shutdown_modules(Duration::from_secs(3)).await;
     }
     #[cfg(not(unix))]
     {
         tokio::select! {
-            Err(e) = running_modules => {
+            Err(e) = handler.start_modules() => {
                 error!("Error running modules: {:?}", e);
-                _ = handler.shutdown_modules(Duration::from_secs(3));
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Ctrl-C received, shutting down");
-                _ = handler.shutdown_modules(Duration::from_secs(3));
             }
         }
+        _ = handler.shutdown_modules(Duration::from_secs(3)).await;
     }
 
     Ok(())

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -151,17 +151,15 @@ async fn main() -> Result<()> {
         tokio::select! {
             Err(e) = handler.start_modules() => {
                 error!("Error running modules: {:?}", e);
-                _ = handler.shutdown_modules(Duration::from_secs(3)).await;
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Ctrl-C received, shutting down");
-                _ = handler.shutdown_modules(Duration::from_secs(3)).await;
             }
             _ = terminate.recv() =>  {
                 info!("SIGTERM received, shutting down");
-                _ = handler.shutdown_modules(Duration::from_secs(3)).await;
             }
         }
+        _ = handler.shutdown_modules(Duration::from_secs(3)).await;
     }
     #[cfg(not(unix))]
     {
@@ -171,9 +169,9 @@ async fn main() -> Result<()> {
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Ctrl-C received, shutting down");
-                _ = handler.shutdown_modules(Duration::from_secs(3)).await;
             }
         }
+        _ = handler.shutdown_modules(Duration::from_secs(3)).await;
     }
 
     Ok(())

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -18,11 +18,6 @@ type AnyMap = Map<dyn Any + Send + Sync>;
 /// Types that implement BusMessage can be sent on the bus - this is mostly for documentation purposes.
 pub trait BusMessage {}
 
-#[derive(Clone, Copy, Debug)]
-pub struct ShutdownSignal;
-
-impl BusMessage for ShutdownSignal {}
-
 pub struct SharedMessageBus {
     channels: Arc<Mutex<AnyMap>>,
     pub metrics: BusMetrics,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -98,18 +98,10 @@ macro_rules! bus_client {
             $(receiver($receiver:ty),)*
         }
     ) => {
-        use $crate::bus::metrics::BusMetrics;
-        #[allow(unused_imports)]
-        use $crate::bus::BusClientReceiver;
-        #[allow(unused_imports)]
-        use $crate::bus::BusClientSender;
-        #[allow(unused_imports)]
-        use $crate::bus::dont_use_this::{get_receiver, get_sender};
-        use $crate::utils::static_type_map::static_type_map;
-        static_type_map! {
+        $crate::utils::static_type_map::static_type_map! {
             $(#[$meta])*
             $pub struct $name (
-                BusMetrics,
+                $crate::bus::metrics::BusMetrics,
                 $(tokio::sync::broadcast::Sender<$sender>,)*
                 $(tokio::sync::broadcast::Receiver<$receiver>,)*
             );
@@ -118,8 +110,8 @@ macro_rules! bus_client {
             pub async fn new_from_bus(bus: $crate::bus::SharedMessageBus) -> $name {
                 $name::new(
                     bus.metrics.clone(),
-                    $(get_sender::<$sender>(&bus).await,)*
-                    $(get_receiver::<$receiver>(&bus).await,)*
+                    $($crate::bus::dont_use_this::get_sender::<$sender>(&bus).await,)*
+                    $($crate::bus::dont_use_this::get_receiver::<$receiver>(&bus).await,)*
                 )
             }
         }

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -18,6 +18,11 @@ type AnyMap = Map<dyn Any + Send + Sync>;
 /// Types that implement BusMessage can be sent on the bus - this is mostly for documentation purposes.
 pub trait BusMessage {}
 
+#[derive(Clone, Copy, Debug)]
+pub struct ShutdownSignal;
+
+impl BusMessage for ShutdownSignal {}
+
 pub struct SharedMessageBus {
     channels: Arc<Mutex<AnyMap>>,
     pub metrics: BusMetrics,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -115,7 +115,7 @@ macro_rules! bus_client {
             );
         }
         impl $name {
-            pub async fn new_from_bus(bus: SharedMessageBus) -> $name {
+            pub async fn new_from_bus(bus: $crate::bus::SharedMessageBus) -> $name {
                 $name::new(
                     bus.metrics.clone(),
                     $(get_sender::<$sender>(&bus).await,)*

--- a/src/bus/command_response.rs
+++ b/src/bus/command_response.rs
@@ -178,14 +178,14 @@ macro_rules! handle_messages {
 
     // Shorthand to listen to topic, and break the loop
     (bus($bus:expr) index($index:ident) break_on($module_name:expr) $($rest:tt)*) => {
-        let $index = unsafe { &mut *Pick::<tokio::sync::broadcast::Receiver<ShutdownModule>>::splitting_get_mut(&mut $bus) };
+        let $index = unsafe { &mut *Pick::<tokio::sync::broadcast::Receiver<$crate::utils::modules::signal::ShutdownModule>>::splitting_get_mut(&mut $bus) };
         paste! {
         handle_messages! {
             bus($bus) index([<$index a>]) $($rest)*
             Ok(shutdown_event) = $index.recv() => {
                 if shutdown_event.module == $module_name {
-                    receive_bus_metrics::<ShutdownModule, _>(&mut $bus);
-                    warn!("Break signal received for module {}", $module_name);
+                    receive_bus_metrics::<$crate::utils::modules::signal::ShutdownModule, _>(&mut $bus);
+                    tracing::warn!("Break signal received for module {}", $module_name);
                     break;
                 }
             }

--- a/src/bus/command_response.rs
+++ b/src/bus/command_response.rs
@@ -207,6 +207,8 @@ macro_rules! handle_messages {
     // Fallback to normal select cases
     (bus($bus:expr) index($index:ident) $($rest:tt)+) => {
         loop {
+            // if false is necessary here so rust understands the loop can be broken
+            // and avoid warnings like "unreachable code"
             if false {
                 break;
             }

--- a/src/bus/command_response.rs
+++ b/src/bus/command_response.rs
@@ -177,15 +177,17 @@ macro_rules! handle_messages {
     };
 
     // Shorthand to listen to topic, and break the loop
-    (bus($bus:expr) index($index:ident) break_on<$message:ty> $($rest:tt)*) => {
-        let $index = unsafe { &mut *Pick::<tokio::sync::broadcast::Receiver<$message>>::splitting_get_mut(&mut $bus) };
+    (bus($bus:expr) index($index:ident) break_on($module_name:expr) $($rest:tt)*) => {
+        let $index = unsafe { &mut *Pick::<tokio::sync::broadcast::Receiver<ShutdownModule>>::splitting_get_mut(&mut $bus) };
         paste! {
         handle_messages! {
             bus($bus) index([<$index a>]) $($rest)*
-            Ok(_) = $index.recv()  => {
-                receive_bus_metrics::<$message, _>(&mut $bus);
-                warn!("Break signal received");
-                break;
+            Ok(shutdown_event) = $index.recv() => {
+                if shutdown_event.module == $module_name {
+                    receive_bus_metrics::<ShutdownModule, _>(&mut $bus);
+                    warn!("Break signal received for module {}", $module_name);
+                    break;
+                }
             }
         }
         }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -916,6 +916,8 @@ impl Consensus {
                     .log_error("Cannot send message over channel")?;
             }
         }
+
+        Ok(())
     }
 
     fn sign_net_message(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -921,6 +921,17 @@ impl Consensus {
                     .log_error("Cannot send message over channel")?;
             }
         }
+
+        if let Some(file) = &self.file {
+            if let Err(e) = Self::save_on_disk(
+                self.config.data_directory.as_path(),
+                file.as_path(),
+                &self.store,
+            ) {
+                warn!("Failed to save consensus storage on disk: {}", e);
+            }
+        }
+
         _ = self.bus.send(ShutdownCompleted {
             module: stringify!(Consensus).to_string(),
         });

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,9 +1,9 @@
 //! Handles all consensus logic up to block commitment.
 
-use crate::utils::logger::LogMe;
 use crate::utils::modules::module_bus_client;
 #[cfg(not(test))]
 use crate::utils::static_type_map::Pick;
+use crate::{bus::BusClientSender, utils::logger::LogMe};
 use crate::{
     bus::{command_response::Query, BusMessage},
     data_availability::DataEvent,
@@ -965,7 +965,7 @@ pub mod test {
         autobahn_testing::test::{
             broadcast, build_tuple, send, AutobahnBusClient, AutobahnTestCtx,
         },
-        bus::SharedMessageBus,
+        bus::{dont_use_this::get_receiver, metrics::BusMetrics, SharedMessageBus},
         mempool::storage::CarHash,
         p2p::network::NetMessage,
         utils::{conf::Conf, crypto},

--- a/src/consensus/api.rs
+++ b/src/consensus/api.rs
@@ -9,6 +9,7 @@ use crate::{
     bus::{
         bus_client,
         command_response::{CmdRespClient, Query},
+        metrics::BusMetrics,
     },
     model::CommonRunContext,
     rest::AppError,

--- a/src/consensus/api.rs
+++ b/src/consensus/api.rs
@@ -9,7 +9,6 @@ use crate::{
     bus::{
         bus_client,
         command_response::{CmdRespClient, Query},
-        SharedMessageBus,
     },
     model::CommonRunContext,
     rest::AppError,

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -447,10 +447,12 @@ impl DataAvailability {
         }
 
         info!(
-            "new block {} with {} txs, last hash = {:?}",
+            "new block {} with {} txs, last hash = {}",
             block.height,
             block.txs.len(),
-            self.blocks.last_block_hash()
+            self.blocks
+                .last_block_hash()
+                .unwrap_or(BlockHash("".to_string()))
         );
 
         // Process the block in node state

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -34,8 +34,8 @@ use futures::{
     SinkExt, StreamExt,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use tokio::{
     net::{TcpListener, TcpStream},
     task::{JoinHandle, JoinSet},

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -4,7 +4,7 @@ mod api;
 mod blocks;
 
 use crate::{
-    bus::{command_response::Query, BusMessage},
+    bus::{command_response::Query, BusClientSender, BusMessage},
     consensus::ConsensusCommand,
     genesis::GenesisEvent,
     handle_messages,
@@ -606,6 +606,7 @@ impl DataAvailability {
 #[cfg(test)]
 mod tests {
     use crate::{
+        bus::BusClientSender,
         mempool::MempoolEvent,
         model::{
             Blob, BlobData, BlobTransaction, Block, BlockHash, BlockHeight, ContractName, Hashable,

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -4,7 +4,7 @@ mod api;
 mod blocks;
 
 use crate::{
-    bus::{bus_client, command_response::Query, BusMessage, SharedMessageBus},
+    bus::{bus_client, command_response::Query, BusMessage, SharedMessageBus, ShutdownSignal},
     consensus::ConsensusCommand,
     genesis::GenesisEvent,
     handle_messages,
@@ -74,6 +74,7 @@ struct DABusClient {
     sender(OutboundMessage),
     sender(DataEvent),
     sender(ConsensusCommand),
+    receiver(ShutdownSignal),
     receiver(Query<ContractName, Contract>),
     receiver(DataNetMessage),
     receiver(PeerEvent),

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -4,7 +4,7 @@ mod api;
 mod blocks;
 
 use crate::{
-    bus::{bus_client, command_response::Query, BusMessage, SharedMessageBus},
+    bus::{command_response::Query, BusMessage},
     consensus::ConsensusCommand,
     genesis::GenesisEvent,
     handle_messages,
@@ -18,10 +18,7 @@ use crate::{
     utils::{
         conf::SharedConf,
         logger::LogMe,
-        modules::{
-            boot_signal::{ShutdownCompleted, ShutdownModule},
-            Module,
-        },
+        modules::{module_bus_client, signal::ShutdownCompleted, Module},
     },
 };
 use anyhow::{Context, Result};
@@ -75,14 +72,12 @@ impl From<DataNetMessage> for NetMessage {
 #[derive(Clone)]
 pub struct QueryBlockHeight {}
 
-bus_client! {
+module_bus_client! {
 #[derive(Debug)]
 struct DABusClient {
     sender(OutboundMessage),
     sender(DataEvent),
     sender(ConsensusCommand),
-    sender(ShutdownCompleted),
-    receiver(ShutdownModule),
     receiver(Query<ContractName, Contract>),
     receiver(DataNetMessage),
     receiver(PeerEvent),
@@ -622,7 +617,7 @@ mod tests {
     use tokio::io::AsyncWriteExt;
     use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
-    use super::{blocks::Blocks, bus_client};
+    use super::{blocks::Blocks, module_bus_client};
     use anyhow::Result;
 
     #[test]
@@ -696,8 +691,7 @@ mod tests {
         }
     }
 
-    use crate::bus::SharedMessageBus;
-    bus_client! {
+    module_bus_client! {
     #[derive(Debug)]
     struct TestBusClient {
         sender(MempoolEvent),

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -297,6 +297,7 @@ impl DataAvailability {
                 }
             }
         }
+        Ok(())
     }
 
     async fn handle_data_message(&mut self, msg: DataNetMessage) -> Result<()> {

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -18,7 +18,7 @@ use crate::{
     utils::{
         conf::SharedConf,
         logger::LogMe,
-        modules::{module_bus_client, signal::ShutdownCompleted, Module},
+        modules::{module_bus_client, Module},
     },
 };
 use anyhow::{Context, Result};
@@ -75,6 +75,7 @@ pub struct QueryBlockHeight {}
 module_bus_client! {
 #[derive(Debug)]
 struct DABusClient {
+    module: DataAvailability,
     sender(OutboundMessage),
     sender(DataEvent),
     sender(ConsensusCommand),
@@ -302,9 +303,7 @@ impl DataAvailability {
                 }
             }
         }
-        _ = self.bus.send(ShutdownCompleted {
-            module: stringify!(DataAvailability).to_string(),
-        });
+        _ = self.bus.shutdown_complete();
 
         Ok(())
     }

--- a/src/data_availability/api.rs
+++ b/src/data_availability/api.rs
@@ -13,6 +13,7 @@ use crate::{
     bus::{
         bus_client,
         command_response::{CmdRespClient, Query},
+        metrics::BusMetrics,
     },
     model::{BlockHeight, CommonRunContext},
     node_state::model::Contract,

--- a/src/data_availability/api.rs
+++ b/src/data_availability/api.rs
@@ -13,7 +13,6 @@ use crate::{
     bus::{
         bus_client,
         command_response::{CmdRespClient, Query},
-        SharedMessageBus,
     },
     model::{BlockHeight, CommonRunContext},
     node_state::model::Contract,

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    bus::{bus_client, BusMessage},
+    bus::{bus_client, BusClientSender, BusMessage},
     consensus::staking::{Stake, Staker},
     handle_messages,
     model::{
@@ -217,7 +217,7 @@ mod tests {
     use assertables::assert_matches;
 
     use super::*;
-    use crate::bus::SharedMessageBus;
+    use crate::bus::{BusClientReceiver, SharedMessageBus};
     use crate::utils::conf::Conf;
     use crate::utils::crypto::BlstCrypto;
     use std::sync::Arc;

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    bus::{bus_client, BusMessage, SharedMessageBus},
+    bus::{bus_client, BusMessage},
     consensus::staking::{Stake, Staker},
     handle_messages,
     model::{

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -154,6 +154,7 @@ impl Indexer {
                         })?;
                 }
             }
+            Ok(())
         } else {
             handle_messages! {
                 on_bus self.bus,
@@ -199,6 +200,7 @@ impl Indexer {
                         })?;
                 }
             }
+            Ok(())
         }
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -4,12 +4,11 @@ mod api;
 pub mod model;
 
 use crate::{
-    bus::{bus_client, SharedMessageBus},
     data_availability::DataEvent,
     handle_messages,
     model::{BlobTransaction, Block, BlockHash, CommonRunContext, ContractName, Hashable},
     node_state::NodeState,
-    utils::modules::Module,
+    utils::modules::{module_bus_client, Module},
 };
 use anyhow::{bail, Context, Error, Result};
 use axum::{
@@ -34,7 +33,7 @@ use tokio::{
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use tracing::{debug, error, info, warn};
 
-bus_client! {
+module_bus_client! {
 #[derive(Debug)]
 struct IndexerBusClient {
     receiver(DataEvent),
@@ -625,9 +624,12 @@ mod test {
         net::{Ipv4Addr, SocketAddr},
     };
 
-    use crate::model::{
-        Blob, BlobData, BlockHeight, ProofData, ProofTransaction, RegisterContractTransaction,
-        Transaction, TransactionData, VerifiedProofTransaction,
+    use crate::{
+        bus::SharedMessageBus,
+        model::{
+            Blob, BlobData, BlockHeight, ProofData, ProofTransaction, RegisterContractTransaction,
+            Transaction, TransactionData, VerifiedProofTransaction,
+        },
     };
 
     use super::*;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -4,6 +4,7 @@ mod api;
 pub mod model;
 
 use crate::{
+    bus::BusClientSender,
     data_availability::DataEvent,
     handle_messages,
     model::{BlobTransaction, Block, BlockHash, CommonRunContext, ContractName, Hashable},

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,7 +1,7 @@
 //! Mempool logic & pending transaction management.
 
 use crate::{
-    bus::{bus_client, command_response::Query, BusMessage, SharedMessageBus},
+    bus::{bus_client, command_response::Query, BusMessage, SharedMessageBus, ShutdownSignal},
     consensus::ConsensusEvent,
     genesis::GenesisEvent,
     handle_messages,
@@ -39,6 +39,7 @@ bus_client! {
 struct MempoolBusClient {
     sender(OutboundMessage),
     sender(MempoolEvent),
+    receiver(ShutdownSignal),
     receiver(SignedByValidator<MempoolNetMessage>),
     receiver(RestApiMessage),
     receiver(ConsensusEvent),
@@ -130,6 +131,7 @@ impl Mempool {
 
         handle_messages! {
             on_bus self.bus,
+            break_on<ShutdownSignal>
             listen<SignedByValidator<MempoolNetMessage>> cmd => {
                 let _ = self.handle_net_message(cmd)
                     .log_error("Handling MempoolNetMessage in Mempool");

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -160,6 +160,7 @@ impl Mempool {
                     .log_error("Creating Data Proposal on tick");
             }
         }
+        Ok(())
     }
 
     /// Creates a cut with local material on QueryNewCut message reception (from consensus)

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,7 +1,7 @@
 //! Mempool logic & pending transaction management.
 
 use crate::{
-    bus::{command_response::Query, BusMessage},
+    bus::{command_response::Query, BusClientSender, BusMessage},
     consensus::ConsensusEvent,
     genesis::GenesisEvent,
     handle_messages,
@@ -534,6 +534,8 @@ impl Mempool {
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use crate::bus::dont_use_this::get_receiver;
+    use crate::bus::metrics::BusMetrics;
     use crate::bus::SharedMessageBus;
     use crate::model::{ContractName, RegisterContractTransaction, Transaction};
     use crate::p2p::network::NetMessage;

--- a/src/mempool/api.rs
+++ b/src/mempool/api.rs
@@ -5,7 +5,7 @@ use hyle_contract_sdk::TxHash;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    bus::{bus_client, BusMessage, SharedMessageBus},
+    bus::{bus_client, BusMessage},
     consensus::staking::Staker,
     model::{
         BlobTransaction, CommonRunContext, Hashable, ProofData, ProofTransaction,

--- a/src/mempool/api.rs
+++ b/src/mempool/api.rs
@@ -5,7 +5,7 @@ use hyle_contract_sdk::TxHash;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    bus::{bus_client, BusMessage},
+    bus::{bus_client, metrics::BusMetrics, BusClientSender, BusMessage},
     consensus::staking::Staker,
     model::{
         BlobTransaction, CommonRunContext, Hashable, ProofData, ProofTransaction,

--- a/src/mempool/storage.rs
+++ b/src/mempool/storage.rs
@@ -26,7 +26,7 @@ pub enum DataProposalVerdict {
 
 pub type Cut = Vec<(ValidatorPublicKey, CarHash)>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub struct Storage {
     pub id: ValidatorPublicKey,
     pub pending_txs: Vec<Transaction>,
@@ -438,7 +438,7 @@ impl Display for Car {
     }
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub struct Poa(pub BTreeSet<ValidatorPublicKey>);
 
 impl std::ops::Deref for Poa {
@@ -454,7 +454,7 @@ impl std::ops::DerefMut for Poa {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Encode, Decode)]
 pub struct Lane {
     cars: Vec<Car>,
     pub poa: Poa,

--- a/src/model.rs
+++ b/src/model.rs
@@ -203,10 +203,18 @@ pub struct HandledBlockOutput {
     pub updated_states: HashMap<ContractName, StateDigest>,
 }
 
-#[derive(
-    Display, Debug, Serialize, Deserialize, Default, Clone, Encode, Decode, PartialEq, Eq, Hash,
-)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, Encode, Decode, PartialEq, Eq, Hash)]
 pub struct BlockHash(pub String);
+
+impl Display for BlockHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.0.get(..HASH_DISPLAY_SIZE * 2).unwrap_or(&self.0)
+        )
+    }
+}
 
 impl Type<Postgres> for BlockHash {
     fn type_info() -> sqlx::postgres::PgTypeInfo {

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -3,16 +3,13 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::{
-    bus::{bus_client, BusMessage, SharedMessageBus},
+    bus::{BusMessage, SharedMessageBus},
     handle_messages,
     model::SharedRunContext,
     utils::{
         conf::SharedConf,
         crypto::SharedBlstCrypto,
-        modules::{
-            boot_signal::{ShutdownCompleted, ShutdownModule},
-            Module,
-        },
+        modules::{module_bus_client, signal::ShutdownCompleted, Module},
     },
 };
 use anyhow::{bail, Result};
@@ -30,11 +27,9 @@ pub enum P2PCommand {
 }
 impl BusMessage for P2PCommand {}
 
-bus_client! {
+module_bus_client! {
 struct P2PBusClient {
-    sender(ShutdownCompleted),
     receiver(P2PCommand),
-    receiver(ShutdownModule),
 }
 }
 

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -3,7 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::{
-    bus::{bus_client, BusMessage, SharedMessageBus},
+    bus::{bus_client, BusMessage, SharedMessageBus, ShutdownSignal},
     handle_messages,
     model::SharedRunContext,
     utils::{conf::SharedConf, crypto::SharedBlstCrypto, modules::Module},
@@ -26,6 +26,7 @@ impl BusMessage for P2PCommand {}
 bus_client! {
 struct P2PBusClient {
     receiver(P2PCommand),
+    receiver(ShutdownSignal),
 }
 }
 
@@ -133,6 +134,7 @@ impl P2P {
 
         handle_messages! {
             on_bus self.bus_client,
+            break_on<ShutdownSignal>
             listen<P2PCommand> cmd => {
                  self.handle_command(cmd)
             }

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -9,7 +9,7 @@ use crate::{
     utils::{
         conf::SharedConf,
         crypto::SharedBlstCrypto,
-        modules::{module_bus_client, signal::ShutdownCompleted, Module},
+        modules::{module_bus_client, Module},
     },
 };
 use anyhow::{bail, Result};
@@ -29,6 +29,7 @@ impl BusMessage for P2PCommand {}
 
 module_bus_client! {
 struct P2PBusClient {
+    module: P2P,
     receiver(P2PCommand),
 }
 }
@@ -177,9 +178,7 @@ impl P2P {
                 }
             }
         }
-        _ = self.bus_client.send(ShutdownCompleted {
-            module: stringify!(P2P).to_string(),
-        });
+        _ = self.bus_client.shutdown_complete();
         Ok(())
     }
 }

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -3,7 +3,7 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::{
-    bus::{BusMessage, SharedMessageBus},
+    bus::{BusClientSender, BusMessage, SharedMessageBus},
     handle_messages,
     model::SharedRunContext,
     utils::{

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -19,6 +19,7 @@ use super::network::{Hello, NetMessage};
 use super::stream::send_net_message;
 use crate::bus::bus_client;
 use crate::bus::SharedMessageBus;
+use crate::bus::ShutdownSignal;
 use crate::consensus::ConsensusNetMessage;
 use crate::data_availability::DataNetMessage;
 use crate::handle_messages;
@@ -35,6 +36,7 @@ struct PeerBusClient {
     sender(PeerEvent),
     sender(DataNetMessage),
     receiver(OutboundMessage),
+    receiver(ShutdownSignal),
 }
 }
 
@@ -190,6 +192,7 @@ impl Peer {
     pub async fn start(&mut self) -> Result<()> {
         handle_messages! {
             on_bus self.bus,
+            break_on<ShutdownSignal>
             listen<OutboundMessage> res => {
                 match res {
                     OutboundMessage::SendMessage { validator_id, msg } => match self.handle_send_message(validator_id, msg).await {

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -187,7 +187,7 @@ impl Peer {
             .ok();
     }
 
-    pub async fn start(&mut self) -> Result<(), Error> {
+    pub async fn start(&mut self) -> Result<()> {
         handle_messages! {
             on_bus self.bus,
             listen<OutboundMessage> res => {
@@ -256,6 +256,7 @@ impl Peer {
                 }
             }
         }
+        Ok(())
     }
 
     pub async fn connect(addr: &str) -> Result<TcpStream, Error> {

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -27,7 +27,7 @@ use crate::model::ValidatorPublicKey;
 use crate::p2p::stream::read_stream;
 use crate::utils::conf::SharedConf;
 use crate::utils::crypto::SharedBlstCrypto;
-use crate::utils::modules::boot_signal::ShutdownModule;
+use crate::utils::modules::signal::ShutdownModule;
 
 bus_client! {
 struct PeerBusClient {

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -18,6 +18,7 @@ use super::network::SignedByValidator;
 use super::network::{Hello, NetMessage};
 use super::stream::send_net_message;
 use crate::bus::bus_client;
+use crate::bus::BusClientSender;
 use crate::bus::SharedMessageBus;
 use crate::consensus::ConsensusNetMessage;
 use crate::data_availability::DataNetMessage;

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -19,7 +19,6 @@ use super::network::{Hello, NetMessage};
 use super::stream::send_net_message;
 use crate::bus::bus_client;
 use crate::bus::SharedMessageBus;
-use crate::bus::ShutdownSignal;
 use crate::consensus::ConsensusNetMessage;
 use crate::data_availability::DataNetMessage;
 use crate::handle_messages;
@@ -28,6 +27,7 @@ use crate::model::ValidatorPublicKey;
 use crate::p2p::stream::read_stream;
 use crate::utils::conf::SharedConf;
 use crate::utils::crypto::SharedBlstCrypto;
+use crate::utils::modules::boot_signal::ShutdownModule;
 
 bus_client! {
 struct PeerBusClient {
@@ -36,7 +36,7 @@ struct PeerBusClient {
     sender(PeerEvent),
     sender(DataNetMessage),
     receiver(OutboundMessage),
-    receiver(ShutdownSignal),
+    receiver(ShutdownModule),
 }
 }
 
@@ -192,7 +192,7 @@ impl Peer {
     pub async fn start(&mut self) -> Result<()> {
         handle_messages! {
             on_bus self.bus,
-            break_on<ShutdownSignal>
+            break_on(stringify!(Peer))
             listen<OutboundMessage> res => {
                 match res {
                     OutboundMessage::SendMessage { validator_id, msg } => match self.handle_send_message(validator_id, msg).await {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -13,7 +13,7 @@ use tower_http::trace::TraceLayer;
 use tracing::info;
 
 use crate::{
-    bus::SharedMessageBus,
+    bus::{BusClientSender, SharedMessageBus},
     handle_messages,
     model::ValidatorPublicKey,
     utils::modules::{module_bus_client, Module},

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,6 +1,5 @@
 //! Public API for interacting with the node.
 
-use crate::{bus::SharedMessageBus, model::ValidatorPublicKey, utils::modules::Module};
 use anyhow::{Context, Result};
 use axum::{
     extract::State,
@@ -13,6 +12,8 @@ use axum_otel_metrics::HttpMetricsLayer;
 use serde::{Deserialize, Serialize};
 use tower_http::trace::TraceLayer;
 use tracing::info;
+
+use crate::{bus::SharedMessageBus, model::ValidatorPublicKey, utils::modules::Module};
 
 pub mod client;
 

--- a/src/single_node_consensus.rs
+++ b/src/single_node_consensus.rs
@@ -137,6 +137,7 @@ impl SingleNodeConsensus {
                 self.handle_new_slot_tick().await?;
             }
         }
+        Ok(())
     }
 
     fn handle_car_proposal_message(&mut self, cmd: OutboundMessage) -> Result<()> {

--- a/src/single_node_consensus.rs
+++ b/src/single_node_consensus.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::bus::command_response::{CmdRespClient, Query};
+use crate::bus::BusClientSender;
 use crate::consensus::{ConsensusEvent, ConsensusInfo, QueryConsensusInfo};
 use crate::genesis::{Genesis, GenesisEvent};
 use crate::mempool::storage::Cut;
@@ -211,6 +212,8 @@ impl SingleNodeConsensus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bus::dont_use_this::get_receiver;
+    use crate::bus::metrics::BusMetrics;
     use crate::bus::{bus_client, SharedMessageBus};
     use crate::mempool::storage::{Car, CarHash, DataProposal};
     use crate::model::{Hashable, ValidatorPublicKey};

--- a/src/single_node_consensus.rs
+++ b/src/single_node_consensus.rs
@@ -130,6 +130,18 @@ impl SingleNodeConsensus {
                 self.handle_new_slot_tick().await?;
             }
         }
+        if let Some(file) = &self.file {
+            if let Err(e) = Self::save_on_disk(
+                self.config.data_directory.as_path(),
+                file.as_path(),
+                &self.store,
+            ) {
+                warn!(
+                    "Failed to save consensus single node storage on disk: {}",
+                    e
+                );
+            }
+        }
 
         _ = self.bus.send(ShutdownCompleted {
             module: stringify!(SingleNodeConsensus).to_string(),

--- a/src/tools/mock_workflow.rs
+++ b/src/tools/mock_workflow.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::{
-    bus::{BusMessage, SharedMessageBus},
+    bus::{BusMessage, SharedMessageBus, ShutdownSignal},
     handle_messages,
     mempool::api::RestApiMessage,
     model::{
@@ -23,6 +23,7 @@ use crate::bus::bus_client;
 bus_client! {
 struct MockWorkflowBusClient {
     sender(RestApiMessage),
+    receiver(ShutdownSignal),
     receiver(RunScenario),
 }
 }
@@ -123,6 +124,7 @@ impl MockWorkflowHandler {
     pub async fn start(&mut self) -> anyhow::Result<()> {
         handle_messages! {
             on_bus self.bus,
+            break_on<ShutdownSignal>
             listen<RunScenario> cmd => {
                 match cmd {
                     RunScenario::StressTest => {

--- a/src/tools/mock_workflow.rs
+++ b/src/tools/mock_workflow.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::{
-    bus::{BusMessage, SharedMessageBus},
+    bus::BusMessage,
     handle_messages,
     mempool::api::RestApiMessage,
     model::{
@@ -9,10 +9,7 @@ use crate::{
         ProofTransaction, RegisterContractTransaction, SharedRunContext, Transaction,
     },
     rest::client::ApiHttpClient,
-    utils::modules::{
-        boot_signal::{ShutdownCompleted, ShutdownModule},
-        Module,
-    },
+    utils::modules::{module_bus_client, signal::ShutdownCompleted, Module},
 };
 use anyhow::Result;
 use hyle_contract_sdk::{Identity, StateDigest};
@@ -21,13 +18,11 @@ use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
-use crate::bus::bus_client;
+// use crate::bus::bus_client;
 
-bus_client! {
+module_bus_client! {
 struct MockWorkflowBusClient {
     sender(RestApiMessage),
-    sender(ShutdownCompleted),
-    receiver(ShutdownModule),
     receiver(RunScenario),
 }
 }
@@ -75,10 +70,7 @@ mod api {
     use axum::{routing::post, Router};
 
     use crate::tools::mock_workflow::RunScenario;
-    use crate::{
-        bus::{bus_client, SharedMessageBus},
-        model::CommonRunContext,
-    };
+    use crate::{bus::bus_client, model::CommonRunContext};
     use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 
     bus_client! {

--- a/src/tools/mock_workflow.rs
+++ b/src/tools/mock_workflow.rs
@@ -9,7 +9,7 @@ use crate::{
         ProofTransaction, RegisterContractTransaction, SharedRunContext, Transaction,
     },
     rest::client::ApiHttpClient,
-    utils::modules::{module_bus_client, signal::ShutdownCompleted, Module},
+    utils::modules::{module_bus_client, Module},
 };
 use anyhow::Result;
 use hyle_contract_sdk::{Identity, StateDigest};
@@ -22,6 +22,7 @@ use tracing::{error, info, warn};
 
 module_bus_client! {
 struct MockWorkflowBusClient {
+    module: MockWorkflowHandler,
     sender(RestApiMessage),
     receiver(RunScenario),
 }
@@ -133,9 +134,7 @@ impl MockWorkflowHandler {
             }
         }
 
-        _ = self.bus.send(ShutdownCompleted {
-            module: stringify!(MockWorkflowHandler).to_string(),
-        });
+        _ = self.bus.shutdown_complete();
         Ok(())
     }
 

--- a/src/tools/mock_workflow.rs
+++ b/src/tools/mock_workflow.rs
@@ -134,6 +134,7 @@ impl MockWorkflowHandler {
                 }
             }
         }
+        Ok(())
     }
 
     async fn stress_test(&mut self) {

--- a/src/tools/mock_workflow.rs
+++ b/src/tools/mock_workflow.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::{
-    bus::BusMessage,
+    bus::{BusClientSender, BusMessage},
     handle_messages,
     mempool::api::RestApiMessage,
     model::{
@@ -70,6 +70,8 @@ impl Module for MockWorkflowHandler {
 mod api {
     use axum::{routing::post, Router};
 
+    use crate::bus::metrics::BusMetrics;
+    use crate::bus::BusClientSender;
     use crate::tools::mock_workflow::RunScenario;
     use crate::{bus::bus_client, model::CommonRunContext};
     use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -313,7 +313,6 @@ mod tests {
     use super::{Db, KeyMaker};
     use anyhow::Result;
     use core::str;
-    
 
     struct TestKeyOrd(usize, usize);
 

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -51,7 +51,6 @@ impl<T: DeserializeOwned> DoubleEndedIterator for Iter<T> {
 }
 
 /// KeyMaker makes it easy to build keys without allocating each time.
-
 pub trait KeyMaker {
     fn make_key<'a>(&self, writer: &'a mut String) -> &'a str;
 }

--- a/src/utils/modules.rs
+++ b/src/utils/modules.rs
@@ -248,7 +248,6 @@ mod tests {
     use signal::ShutdownModule;
     use std::fs::File;
     use tempfile::tempdir;
-    use tokio::runtime::Runtime;
 
     #[derive(Default, bincode::Encode, bincode::Decode)]
     struct TestStruct {
@@ -325,20 +324,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_module() {
-        let rt = Runtime::new().unwrap();
-
         let shared_bus = SharedMessageBus::new(BusMetrics::global("id".to_string()));
         let mut handler = ModulesHandler::new(&shared_bus).await;
-
-        rt.block_on(async {
-            handler
-                .build_module::<TestModule>(
-                    TestBusClient::new_from_bus(shared_bus.new_handle()).await,
-                )
-                .await
-                .unwrap();
-            assert_eq!(handler.modules.len(), 1);
-        });
+        handler
+            .build_module::<TestModule>(TestBusClient::new_from_bus(shared_bus.new_handle()).await)
+            .await
+            .unwrap();
+        assert_eq!(handler.modules.len(), 1);
     }
 
     #[tokio::test]

--- a/src/utils/modules.rs
+++ b/src/utils/modules.rs
@@ -1,6 +1,6 @@
 use std::{any::type_name, fs, future::Future, path::Path, pin::Pin, time::Duration};
 
-use anyhow::{anyhow, Context, Error, Result};
+use anyhow::{Context, Error, Result};
 use rand::{distributions::Alphanumeric, Rng};
 use signal::ShutdownCompleted;
 use tokio::task::JoinHandle;

--- a/src/utils/modules.rs
+++ b/src/utils/modules.rs
@@ -169,7 +169,7 @@ impl ModulesHandler {
     /// Shutdown modules in reverse order (start A, B, C, shutdown C, B, A)
     pub async fn shutdown_modules(&mut self, timeout: Duration) -> Result<()> {
         for module_name in self.started_modules.drain(..).rev() {
-            if !vec!["Genesis"].contains(&module_name) {
+            if !["Genesis"].contains(&module_name) {
                 _ = tokio::time::timeout(timeout, self.bus.shutdown_module(module_name))
                     .await
                     .log_error(format!("Shutting down module {module_name}"));

--- a/src/utils/static_type_map.rs
+++ b/src/utils/static_type_map.rs
@@ -18,13 +18,13 @@ macro_rules! static_type_map {
         $(#[$meta:meta])*
         $pub:vis struct $name:ident ($($t1:ty,)+);
     ) => {
-        use paste::paste;
-        paste! {
+        paste::paste! {
             // Wrap it in a module to make the member names private
             mod [<$name:snake>] {
+                #[allow(unused)]
                 use super::*;
-                use paste::paste;
-                static_type_map! {
+
+                $crate::utils::static_type_map::static_type_map! {
                     $(#[$meta])*
                     ha: $pub struct $name ($($t1,)+) {}
                 }
@@ -38,8 +38,8 @@ macro_rules! static_type_map {
         $(#[$meta:meta])*
         $index:ident: $pub:vis struct $name:ident ($t1:ty, $($t2:ty,)*) { $($idx:ident: $t3:ty,)* }
     ) => {
-        paste! {
-            static_type_map! {
+        paste::paste! {
+            $crate::utils::static_type_map::static_type_map! {
                 $(#[$meta])*
                 [<ha $index>]: $pub struct $name ( $($t2,)* ) {
                     $($idx: $t3,)*


### PR DESCRIPTION
- adapt handle_messages a bit (remove nested generated blocks)
- store receivers in variables before select loop
- clean receivers (consume remaining messages) after loop breaks
- order start/stop : start A, B, C, close C, B, A
- persist mempool/consensus on shutdown

Notes
On pimp la macro bus_client en rajoutant des while loops après la select loop, pour vider les topics écoutés dans la select loop (un event shutdown fait break la loop sans garantie d'avoir tout consommé).
Persister le state n'est pertinent que pour redémarrer sans perdre des txs à traiter. Donc dans Mempool, toutes les txs non encore commit doivent être persistées pour ne pas être perdues, et traiter au prochain démarrage de la node.
Il faut ordonner le démarrage des modules, pour ouvrir les apis en dernier, et les close en premier, sinon par exemple mempool est closed, alors que la rest api est encore en train d'amener des txs, qui faileront sans être persistées.

Closes #385 