### PR TITLE
🐛 Hash all critical fields in ConsensusProposal, refactor

### DIFF
--- a/src/consensus/role_leader.rs
+++ b/src/consensus/role_leader.rs
@@ -198,7 +198,9 @@ impl LeaderRole for Consensus {
 
             // Aggregates them into a *Prepare* Quorum Certificate
             let prepvote_signed_aggregation = self.crypto.sign_aggregate(
-                ConsensusNetMessage::PrepareVote(self.bft_round_state.consensus_proposal.hash()),
+                ConsensusNetMessage::PrepareVote(
+                    self.bft_round_state.consensus_proposal.hash(),
+                ),
                 aggregates,
             )?;
 

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -103,15 +103,11 @@ impl Display for ConsensusNetMessage {
             ConsensusNetMessage::ValidatorCandidacy(candidacy) => {
                 write!(f, "{} (CP hash {})", enum_variant, candidacy)
             }
-            ConsensusNetMessage::Timeout(hash, next_leader) => {
-                write!(
-                    f,
-                    "{} - CP hash {} - Next Leader {}",
-                    enum_variant, hash, next_leader
-                )
+            ConsensusNetMessage::Timeout(slot, view) => {
+                write!(f, "{} - Slot: {} View: {}", enum_variant, slot, view)
             }
-            ConsensusNetMessage::TimeoutCertificate(cert, hash) => {
-                _ = writeln!(f, "{} - CP hash: {}", enum_variant, hash);
+            ConsensusNetMessage::TimeoutCertificate(cert, slot, view) => {
+                _ = writeln!(f, "{} - Slot: {} View: {}", enum_variant, slot, view);
                 _ = write!(f, "Certificate {} with validators ", cert.signature);
                 for v in cert.validators.iter() {
                     _ = write!(f, "{},", v);

--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -364,7 +364,11 @@ impl DataAvailability {
         let hash = block.hash();
         // if new block is already handled, ignore it
         if self.blocks.contains(&hash) {
-            warn!("Block {} {} already exists !", block.height(), block.hash());
+            warn!(
+                "Block {} {} already exists !",
+                block.height(),
+                block.hash()
+            );
             return;
         }
         // if new block is not the next block in the chain, buffer
@@ -422,7 +426,12 @@ impl DataAvailability {
             error!("storing block: {}", e);
             return;
         }
-        trace!("Block {} {}: {:#?}", block.height(), block.hash(), block);
+        trace!(
+            "Block {} {}: {:#?}",
+            block.height(),
+            block.hash(),
+            block
+        );
 
         info!(
             "new block {} {} with {} txs, last hash = {}",
@@ -433,7 +442,11 @@ impl DataAvailability {
         );
         debug!(
             "Transactions: {:#?}",
-            block.txs().iter().map(|tx| tx.hash().0).collect::<Vec<_>>()
+            block
+                .txs()
+                .iter()
+                .map(|tx| tx.hash().0)
+                .collect::<Vec<_>>()
         );
 
         // Send the block

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -8,9 +8,9 @@ use crate::{
     handle_messages,
     mempool::DataProposal,
     model::{
-        get_current_timestamp_ms, BlobProofOutput, BlobTransaction, Hashable, ProofData,
-        RegisterContractTransaction, SharedRunContext, SignedBlock, Transaction, TransactionData,
-        ValidatorPublicKey, VerifiedProofTransaction,
+        BlobProofOutput, BlobTransaction, Hashable, ProofData, RegisterContractTransaction,
+        SharedRunContext, SignedBlock, Transaction, TransactionData, ValidatorPublicKey,
+        VerifiedProofTransaction,
     },
     p2p::network::PeerEvent,
     utils::{
@@ -457,8 +457,8 @@ impl Genesis {
                 slot: 0,
                 view: 0,
                 round_leader: round_leader.clone(),
-                // TODO: genesis block should have a consistent timestamp
-                timestamp: get_current_timestamp_ms(),
+                // TODO: genesis block should have a consistent, up-to-date timestamp
+                timestamp: 1735689600000, // 1st of Jan 25 for now
                 // TODO: We aren't actually storing the data proposal above, so we cannot store it here,
                 // or we might mistakenly request data from that cut, but mempool hasn't seen it.
                 // This should be fixed by storing the data proposal in mempool or handling this whole thing differently.

--- a/src/model/consensus.rs
+++ b/src/model/consensus.rs
@@ -1,9 +1,11 @@
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use sha3::{Digest, Sha3_256};
 use strum_macros::IntoStaticStr;
 
 use super::crypto::{AggregateSignature, SignedByValidator};
 use super::mempool::Cut;
+use super::Hashable;
 use staking::model::ValidatorPublicKey;
 
 pub type Slot = u64;
@@ -27,18 +29,18 @@ pub struct ValidatorCandidacy {
     pub peer_address: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 pub struct NewValidatorCandidate {
     pub pubkey: ValidatorPublicKey, // TODO: possible optim: the pubkey is already present in the msg,
     pub msg: SignedByValidator<ConsensusNetMessage>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq, Default)]
 pub struct QuorumCertificateHash(pub Vec<u8>);
 
 pub type QuorumCertificate = AggregateSignature;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct TimeoutCertificate(ConsensusProposalHash, QuorumCertificate);
 
 // A Ticket is necessary to send a valid prepare
@@ -50,14 +52,18 @@ pub enum Ticket {
     TimeoutQC(QuorumCertificate),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq, Default)]
 pub struct ConsensusProposalHash(pub String);
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Encode, Decode, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 pub struct ConsensusProposal {
     // These first few items are checked when receiving the proposal from the leader.
     pub slot: Slot,
     pub view: View,
+    // This field is necessary for joining the network.
+    // Without it, new joiners cannot safely know who the leader is
+    // as we cannot verify that the sender of the Prepare message is indeed the leader.
+    // Additionally, this information is not present in any other message.
     pub round_leader: ValidatorPublicKey,
     // Below items aren't.
     pub cut: Cut,
@@ -66,10 +72,41 @@ pub struct ConsensusProposal {
     pub parent_hash: ConsensusProposalHash,
 }
 
-type NextLeader = ValidatorPublicKey;
+/// This is the hash of the proposal, signed by validators
+/// Any consensus-critical data should be hashed here.
+impl Hashable<ConsensusProposalHash> for ConsensusProposal {
+    fn hash(&self) -> ConsensusProposalHash {
+        let mut hasher = Sha3_256::new();
+        hasher.update(self.slot.to_le_bytes());
+        hasher.update(self.view.to_le_bytes());
+        hasher.update(&self.round_leader.0);
+        self.cut.iter().for_each(|(pubkey, hash, _)| {
+            hasher.update(&pubkey.0);
+            hasher.update(hash.0.as_bytes());
+        });
+        self.new_validators_to_bond.iter().for_each(|val| {
+            hasher.update(&val.pubkey.0);
+        });
+        hasher.update(self.timestamp.to_le_bytes());
+        hasher.update(self.parent_hash.0.as_bytes());
+        ConsensusProposalHash(hex::encode(hasher.finalize()))
+    }
+}
+
+impl std::hash::Hash for ConsensusProposalHash {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(self.0.as_bytes());
+    }
+}
+
+impl std::hash::Hash for ConsensusProposal {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Hashable::<ConsensusProposalHash>::hash(self).hash(state);
+    }
+}
 
 #[derive(
-    Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq, Hash, IntoStaticStr,
+    Debug, Serialize, Deserialize, Clone, Encode, Decode, PartialEq, Eq, IntoStaticStr, Hash,
 )]
 pub enum ConsensusNetMessage {
     Prepare(ConsensusProposal, Ticket),
@@ -77,7 +114,109 @@ pub enum ConsensusNetMessage {
     Confirm(QuorumCertificate),
     ConfirmAck(ConsensusProposalHash),
     Commit(QuorumCertificate, ConsensusProposalHash),
-    Timeout(ConsensusProposalHash, NextLeader),
-    TimeoutCertificate(QuorumCertificate, ConsensusProposalHash),
+    Timeout(Slot, View),
+    TimeoutCertificate(QuorumCertificate, Slot, View),
     ValidatorCandidacy(ValidatorCandidacy),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        mempool::DataProposalHash,
+        model::crypto::{Signature, ValidatorSignature},
+    };
+
+    #[test]
+    fn test_consensus_proposal_hash() {
+        use super::*;
+        let proposal = ConsensusProposal {
+            slot: 1,
+            view: 1,
+            round_leader: ValidatorPublicKey(vec![1, 2, 3]),
+            cut: Cut::default(),
+            new_validators_to_bond: vec![],
+            timestamp: 1,
+            parent_hash: ConsensusProposalHash("".to_string()),
+        };
+        let hash = proposal.hash();
+        assert_eq!(hash.0.len(), 64);
+    }
+    #[test]
+    fn test_consensus_proposal_hash_ignored_fields() {
+        use super::*;
+        let mut a = ConsensusProposal {
+            slot: 1,
+            view: 1,
+            round_leader: ValidatorPublicKey(vec![1, 2, 3]),
+            cut: vec![(
+                ValidatorPublicKey(vec![1]),
+                DataProposalHash("propA".to_string()),
+                AggregateSignature::default(),
+            )],
+            new_validators_to_bond: vec![NewValidatorCandidate {
+                pubkey: ValidatorPublicKey(vec![1, 2, 3]),
+                msg: SignedByValidator {
+                    msg: ConsensusNetMessage::PrepareVote(ConsensusProposalHash("".to_string())),
+                    signature: ValidatorSignature {
+                        signature: Signature(vec![1, 2, 3]),
+                        validator: ValidatorPublicKey(vec![1, 2, 3]),
+                    },
+                },
+            }],
+            timestamp: 1,
+            parent_hash: ConsensusProposalHash("parent".to_string()),
+        };
+        let mut b = ConsensusProposal {
+            slot: 1,
+            view: 1,
+            round_leader: ValidatorPublicKey(vec![1, 2, 3]),
+            cut: vec![(
+                ValidatorPublicKey(vec![1]),
+                DataProposalHash("propA".to_string()),
+                AggregateSignature {
+                    signature: Signature(vec![1, 2, 3]),
+                    validators: vec![ValidatorPublicKey(vec![1, 2, 3])],
+                },
+            )],
+            new_validators_to_bond: vec![NewValidatorCandidate {
+                pubkey: ValidatorPublicKey(vec![1, 2, 3]),
+                msg: SignedByValidator {
+                    msg: ConsensusNetMessage::PrepareVote(ConsensusProposalHash(
+                        "differebt".to_string(),
+                    )),
+                    signature: ValidatorSignature {
+                        signature: Signature(vec![]),
+                        validator: ValidatorPublicKey(vec![]),
+                    },
+                },
+            }],
+            timestamp: 1,
+            parent_hash: ConsensusProposalHash("parent".to_string()),
+        };
+        assert_eq!(a.hash(), b.hash());
+        a.timestamp = 2;
+        assert_ne!(a.hash(), b.hash());
+        b.timestamp = 2;
+        assert_eq!(a.hash(), b.hash());
+
+        a.slot = 2;
+        assert_ne!(a.hash(), b.hash());
+        b.slot = 2;
+        assert_eq!(a.hash(), b.hash());
+
+        a.view = 2;
+        assert_ne!(a.hash(), b.hash());
+        b.view = 2;
+        assert_eq!(a.hash(), b.hash());
+
+        a.round_leader = ValidatorPublicKey(vec![4, 5, 6]);
+        assert_ne!(a.hash(), b.hash());
+        b.round_leader = ValidatorPublicKey(vec![4, 5, 6]);
+        assert_eq!(a.hash(), b.hash());
+
+        a.parent_hash = ConsensusProposalHash("different".to_string());
+        assert_ne!(a.hash(), b.hash());
+        b.parent_hash = ConsensusProposalHash("different".to_string());
+        assert_eq!(a.hash(), b.hash());
+    }
 }


### PR DESCRIPTION
Don't use the consensusProposalHash when timing out, don't pass next_leader as it's unnecessary