### PR TITLE
fix: build hyle-model with sha3 dependency for risc0

### DIFF
--- a/crates/contract-sdk/Cargo.toml
+++ b/crates/contract-sdk/Cargo.toml
@@ -22,7 +22,7 @@ sp1-zkvm = { version = "4.0.0-rc.8", optional = true }
 mockall = "0.13.0"
 
 [features]
-risc0 = ["dep:risc0-zkvm"]
+risc0 = ["dep:risc0-zkvm", "hyle_model/sha3"]
 sp1 = ["dep:sp1-zkvm"]
 tracing = ["dep:tracing"]
 full-model = ["hyle_model/full"]

--- a/crates/hyle-model/Cargo.toml
+++ b/crates/hyle-model/Cargo.toml
@@ -34,3 +34,4 @@ full = [
   "dep:anyhow"
 ]
 sqlx = ["dep:sqlx"]
+sha3 = ["dep:sha3"]


### PR DESCRIPTION
### Problem:
Can't build example contracts against the latest `hyle` because they depend on `contract-sdk` with `risc0` feature, so `sha3` dependency is not included for `hyle-model` module, which leads to build error, because `sha3` is used in `crates/hyle-model/src/contract.rs` for blob transactions.

### Proposed solution:
Add a new feature for `hyle-model` called `sha3` which includes just `sha3` dependency and enable it for `contract-sdk` when it's being built with `risc0` feature.