### PR TITLE
👷‍♂️ Default workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ members = [
     "crates/hyle-loadtest",
     "crates/hyle-model",
     "crates/hyle-verifiers",
+    ".",
+]
+default-members = [
+    "crates/contracts",
+    "crates/hyle-loadtest",
+    "crates/hyle-model",
+    ".",
 ]
 resolver = "2"
 


### PR DESCRIPTION
This allows doing `cargo run --bin hyle-loadtest` from the root