### PR TITLE
💚 Fix release workflow by removing bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,36 +34,4 @@ jobs:
         with:
           body_path: RELEASE_NOTES.md
 
-  bump-version:
-    runs-on: ubuntu-latest 
-    name: Bump version
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.HYLE_GH_APP_ID }}
-          private-key: ${{ secrets.HYLE_GH_APP_SECRET }}
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: "Write cargo.toml"
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          # Strip 'v' from NEW_VERSION if it starts with it
-          CLEAN_VERSION=$(echo "$VERSION" | sed 's/^v//')
-          sed -i "s/^version = \".*\"$/version = \"$CLEAN_VERSION\"/" Cargo.toml
-          cargo update hyle
-      - name: Create Pull Request
-        id: cpr
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          committer: hyle-gh-bot[bot] <196068951+hyle-gh-bot[bot]@users.noreply.github.com>
-          commit-message: "🔖 Bump version to ${{ github.ref_name }}"
-          title: "🔖 Bump version to ${{ github.ref_name }}"
 


### PR DESCRIPTION
as it's broken & needs to be done *before* tagging the version
