### PR TITLE
⚡  Remove two simple slowdown cases

### DIFF
--- a/crates/hyle-model/src/node/mempool.rs
+++ b/crates/hyle-model/src/node/mempool.rs
@@ -39,7 +39,6 @@ impl DataProposal {
                 TransactionData::Blob(_) => {}
             }
         });
-        *self.hash_cache.write().unwrap() = None;
     }
 }
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1007,8 +1007,9 @@ impl Mempool {
             tx,
         };
 
-        let error_log = format!("Sending Status event {:?}", status_event);
-        self.bus.send(status_event).context(error_log)?;
+        self.bus
+            .send(status_event)
+            .context(format!("Sending Status event for TX {}", tx_hash))?;
 
         Ok(())
     }


### PR DESCRIPTION
- we don't need to clear the data-proposal cache when removing proofs
- the context ended up serialising full blobs slowly, this is un-necessary.