### PR TITLE
♻️ Refactor view/CP in consensus

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -96,12 +96,16 @@ receiver(Query<QueryConsensusStakingState, Staking>),
 }
 }
 
-// TODO: move struct to model.rs ?
 #[derive(BorshSerialize, BorshDeserialize, Default)]
 pub struct BFTRoundState {
-    consensus_proposal: ConsensusProposal,
-    last_cut: Cut,
+    // This should always reflect safe, trusted values
     staking: Staking,
+    slot: Slot,
+    view: View,
+    parent_hash: ConsensusProposalHash,
+
+    current_proposal: ConsensusProposal,
+    last_cut_seen: Cut,
 
     leader: LeaderState,
     follower: FollowerState,
@@ -159,26 +163,28 @@ impl DerefMut for Consensus {
 }
 
 impl Consensus {
-    fn next_leader(&self) -> Result<ValidatorPublicKey> {
+    fn round_leader(&self) -> Result<ValidatorPublicKey> {
         // Find out who the next leader will be.
-        let leader_index = self
-            .bft_round_state
-            .staking
-            .bonded()
-            .iter()
-            .position(|v| v == &self.bft_round_state.consensus_proposal.round_leader)
-            .context(format!(
-                "Leader {} not found in validators",
-                &self.bft_round_state.consensus_proposal.round_leader,
-            ))?;
+        // For now, this is round-robin on slot + view for simplicity.
+        // (we remove 1 for backwards compatibility of the tests when making the change)
+        let index = (self.bft_round_state.slot as usize + self.bft_round_state.view as usize)
+            .wrapping_sub(1)
+            % self.bft_round_state.staking.bonded().len();
 
+        // Get the next leader based on the random index
         Ok(self
             .bft_round_state
             .staking
             .bonded()
-            .get((leader_index + 1) % self.bft_round_state.staking.bonded().len())
+            .get(index)
             .context("No next leader found")?
             .clone())
+    }
+    fn next_view_leader(&mut self) -> Result<ValidatorPublicKey> {
+        self.bft_round_state.view += 1;
+        let res = self.round_leader();
+        self.bft_round_state.view -= 1;
+        res
     }
 
     /// Reset bft_round_state for the next round of consensus.
@@ -189,68 +195,58 @@ impl Consensus {
             _ => bail!("Cannot finish_round unless synchronized to the consensus."),
         }
 
-        let round_proposal_hash = self.bft_round_state.consensus_proposal.hashed();
-        let round_parent_hash =
-            std::mem::take(&mut self.bft_round_state.consensus_proposal.parent_hash);
+        // Reset some state
+        self.bft_round_state.leader = LeaderState::default();
 
-        let staking_actions =
-            std::mem::take(&mut self.bft_round_state.consensus_proposal.staking_actions);
-
-        // Reset round state, carrying over staking and current proposal.
-        self.bft_round_state = BFTRoundState {
-            last_cut: std::mem::take(&mut self.bft_round_state.consensus_proposal.cut),
-            consensus_proposal: ConsensusProposal {
-                slot: self.bft_round_state.consensus_proposal.slot,
-                view: self.bft_round_state.consensus_proposal.view,
-                timestamp: self.bft_round_state.consensus_proposal.timestamp,
-                round_leader: std::mem::take(
-                    &mut self.bft_round_state.consensus_proposal.round_leader,
-                ),
-                ..ConsensusProposal::default()
-            },
-            staking: std::mem::take(&mut self.bft_round_state.staking),
-            follower: FollowerState {
-                buffered_prepares: std::mem::take(
-                    &mut self.bft_round_state.follower.buffered_prepares,
-                ),
-                ..FollowerState::default()
-            },
-            ..BFTRoundState::default()
-        };
-
-        // If we finish the round via a committed proposal, update some state
         match ticket {
-            Some(Ticket::CommitQC(qc)) | Some(Ticket::ForcedCommitQc(qc)) => {
-                self.bft_round_state.consensus_proposal.parent_hash = round_proposal_hash;
-                self.bft_round_state.consensus_proposal.slot += 1;
-                self.bft_round_state.consensus_proposal.view = 0;
-                // TODO set None if ForcedCommitQc
-                self.bft_round_state.follower.buffered_quorum_certificate = Some(qc);
-                let staking = &mut self.store.bft_round_state.staking;
-                for action in staking_actions {
+            // We finished the round with a committed proposal for the slot
+            Some(Ticket::CommitQC(_)) | Some(Ticket::ForcedCommitQc(_)) => {
+                self.bft_round_state.slot += 1;
+                self.bft_round_state.view = 0;
+                self.bft_round_state.parent_hash = self.bft_round_state.current_proposal.hashed();
+
+                // Store the last commited QC to avoid issues when parsing Commit messages before Prepare
+                self.bft_round_state.follower.buffered_quorum_certificate = match ticket {
+                    Some(Ticket::CommitQC(qc)) => Some(qc),
+                    Some(Ticket::ForcedCommitQc(_)) => None,
+                    _ => unreachable!(),
+                };
+                for action in
+                    std::mem::take(&mut self.bft_round_state.current_proposal.staking_actions)
+                {
                     match action {
                         // Any new validators are added to the consensus and removed from candidates.
                         ConsensusStakingAction::Bond { candidate } => {
                             debug!("🎉 New validator bonded: {}", candidate.pubkey);
-                            staking
+                            self.store
+                                .bft_round_state
+                                .staking
                                 .bond(candidate.pubkey)
                                 .map_err(|e| anyhow::anyhow!(e))?;
                         }
                         ConsensusStakingAction::PayFeesForDaDi {
                             lane_id,
                             cumul_size,
-                        } => staking
+                        } => self
+                            .store
+                            .bft_round_state
+                            .staking
                             .pay_for_dadi(lane_id, cumul_size)
                             .map_err(|e| anyhow::anyhow!(e))?,
                     }
                 }
-                staking.distribute().map_err(|e| anyhow::anyhow!(e))?;
+                self.store
+                    .bft_round_state
+                    .staking
+                    .distribute()
+                    .map_err(|e| anyhow::anyhow!(e))?;
             }
-            Some(Ticket::TimeoutQC(_)) => {
-                self.bft_round_state.consensus_proposal.parent_hash = round_parent_hash;
-                // FIXME: I think TimeoutQC should hold the view, in case we missed mutliple views
+            // We finished the round with a timeout
+            Some(Ticket::TimeoutQC(qc)) => {
+                // FIXME: I think TimeoutQC should hold the view, in case we missed multiple views
                 // at once
-                self.bft_round_state.consensus_proposal.view += 1;
+                self.bft_round_state.view += 1;
+                self.bft_round_state.follower.buffered_quorum_certificate = Some(qc);
             }
             els => {
                 bail!("Invalid ticket here {:?}", els);
@@ -259,13 +255,11 @@ impl Consensus {
 
         debug!(
             "🥋 Ready for slot {}, view {}",
-            self.bft_round_state.consensus_proposal.slot,
-            self.bft_round_state.consensus_proposal.view
+            self.bft_round_state.slot, self.bft_round_state.view
         );
 
-        self.bft_round_state.consensus_proposal.round_leader = self.next_leader()?;
-
-        if self.bft_round_state.consensus_proposal.round_leader == *self.crypto.validator_pubkey() {
+        let round_leader = self.round_leader()?;
+        if round_leader == *self.crypto.validator_pubkey() {
             self.bft_round_state.state_tag = StateTag::Leader;
             debug!("👑 I'm the new leader! 👑")
         } else {
@@ -401,7 +395,7 @@ impl Consensus {
 
         trace!(
             "📩 Slot {} validated votes: {} / {} ({} validators for a total bond = {})",
-            self.bft_round_state.consensus_proposal.slot,
+            self.bft_round_state.current_proposal.slot,
             voting_power,
             2 * f + 1,
             self.bft_round_state.staking.bonded().len(),
@@ -450,8 +444,8 @@ impl Consensus {
         } = msg.clone();
 
         match net_message {
-            ConsensusNetMessage::Prepare(consensus_proposal, ticket) => {
-                self.on_prepare(sender, consensus_proposal, ticket)
+            ConsensusNetMessage::Prepare(consensus_proposal, ticket, view) => {
+                self.on_prepare(sender, consensus_proposal, ticket, view)
             }
             ConsensusNetMessage::PrepareVote(consensus_proposal_hash) => {
                 self.on_prepare_vote(msg, consensus_proposal_hash)
@@ -510,11 +504,11 @@ impl Consensus {
         commit_quorum_certificate: QuorumCertificate,
         proposal_hash_hint: ConsensusProposalHash,
     ) -> Result<()> {
-        if self.bft_round_state.consensus_proposal.hashed() != proposal_hash_hint {
+        if self.bft_round_state.current_proposal.hashed() != proposal_hash_hint {
             warn!(
                 "Received Commit for proposal {:?} but expected {:?}. Ignoring.",
                 proposal_hash_hint,
-                self.bft_round_state.consensus_proposal.hashed()
+                self.bft_round_state.current_proposal.hashed()
             );
             return Ok(());
         }
@@ -533,7 +527,7 @@ impl Consensus {
             self.bus.send(ConsensusEvent::CommitConsensusProposal(
                 CommittedConsensusProposal {
                     staking: self.bft_round_state.staking.clone(),
-                    consensus_proposal: self.bft_round_state.consensus_proposal.clone(),
+                    consensus_proposal: self.bft_round_state.current_proposal.clone(),
                     certificate: commit_quorum_certificate.clone(),
                 },
             )),
@@ -542,7 +536,7 @@ impl Consensus {
 
         debug!(
             "📈 Slot {} committed",
-            &self.bft_round_state.consensus_proposal.slot
+            &self.bft_round_state.current_proposal.slot
         );
 
         self.carry_on_with_ticket(Ticket::CommitQC(commit_quorum_certificate))
@@ -558,7 +552,7 @@ impl Consensus {
 
         debug!(
             "Current consensus proposal: {}",
-            self.bft_round_state.consensus_proposal
+            self.bft_round_state.current_proposal
         );
 
         // Verify that the validator is not already part of the consensus
@@ -622,13 +616,12 @@ impl Consensus {
                     // Trigger state transition to mutiny
                     info!(
                         "⏰ Trigger timeout for slot {} and view {}",
-                        self.bft_round_state.consensus_proposal.slot,
-                        self.bft_round_state.consensus_proposal.view
+                        self.bft_round_state.slot, self.bft_round_state.view
                     );
 
                     let timeout_message = ConsensusNetMessage::Timeout(
-                        self.bft_round_state.consensus_proposal.slot,
-                        self.bft_round_state.consensus_proposal.view,
+                        self.bft_round_state.slot,
+                        self.bft_round_state.view,
                     );
 
                     let signed_timeout_message = self
@@ -637,8 +630,8 @@ impl Consensus {
 
                     self.on_timeout(
                         signed_timeout_message,
-                        self.bft_round_state.consensus_proposal.slot,
-                        self.bft_round_state.consensus_proposal.view,
+                        self.bft_round_state.slot,
+                        self.bft_round_state.view,
                     )?;
 
                     self.broadcast_net_message(timeout_message)?;
@@ -694,22 +687,7 @@ impl Consensus {
             listen<GenesisEvent> msg => {
                 match msg {
                     GenesisEvent::GenesisBlock(signed_block) => {
-                        self.bft_round_state.consensus_proposal.parent_hash = signed_block.hashed();
-                        self.bft_round_state.consensus_proposal.round_leader = signed_block.consensus_proposal.round_leader.clone();
-
-                        if self.bft_round_state.consensus_proposal.round_leader == *self.crypto.validator_pubkey() {
-                            self.bft_round_state.state_tag = StateTag::Leader;
-                            self.bft_round_state.consensus_proposal.slot = 1;
-                            info!("👑 Starting consensus as leader");
-                        } else {
-                            self.bft_round_state.state_tag = StateTag::Follower;
-                            self.bft_round_state.consensus_proposal.slot = 1;
-                            info!(
-                                "💂‍♂️ Starting consensus as follower of leader {}",
-                                self.bft_round_state.consensus_proposal.round_leader
-                            );
-                        }
-                        // Now wait until we have processed the genesis block to update our Staking.
+                        // Wait until we have processed the genesis block to update our Staking.
                         module_handle_messages! {
                             on_bus self.bus,
                             listen<NodeStateEvent> event => {
@@ -723,6 +701,23 @@ impl Consensus {
                                 }
                             }
                         };
+
+                        self.bft_round_state.parent_hash = signed_block.hashed();
+                        self.bft_round_state.slot = 1;
+                        self.bft_round_state.view = 0;
+                        let round_leader = self.round_leader()?;
+
+                        if round_leader == *self.crypto.validator_pubkey() {
+                            self.bft_round_state.state_tag = StateTag::Leader;
+                            info!("👑 Starting consensus as leader");
+                        } else {
+                            self.bft_round_state.state_tag = StateTag::Follower;
+                            info!(
+                                "💂‍♂️ Starting consensus as follower of leader {}",
+                                round_leader
+                            );
+                        }
+
                         // Send a CommitConsensusProposal for the genesis block
                         _ = log_error!(self
                             .bus
@@ -784,9 +779,9 @@ impl Consensus {
                 let _ = log_error!(self.handle_net_message(cmd), "Consensus message failed");
             }
             command_response<QueryConsensusInfo, ConsensusInfo> _ => {
-                let slot = self.bft_round_state.consensus_proposal.slot;
-                let view = self.bft_round_state.consensus_proposal.view;
-                let round_leader = self.bft_round_state.consensus_proposal.round_leader.clone();
+                let slot = self.bft_round_state.slot;
+                let view = self.bft_round_state.view;
+                let round_leader = self.round_leader()?;
                 let validators = self.bft_round_state.staking.bonded().clone();
                 Ok(ConsensusInfo { slot, view, round_leader, validators })
             }
@@ -929,11 +924,9 @@ pub mod test {
                 self.add_trusted_validator(other_crypto.validator_pubkey());
             }
 
-            self.consensus.bft_round_state.consensus_proposal.slot = 1;
-            self.consensus
-                .bft_round_state
-                .consensus_proposal
-                .parent_hash = ConsensusProposalHash("genesis".to_string());
+            self.consensus.bft_round_state.slot = 1;
+            self.consensus.bft_round_state.parent_hash =
+                ConsensusProposalHash("genesis".to_string());
 
             if index == 0 {
                 self.consensus.bft_round_state.state_tag = StateTag::Leader;
@@ -941,11 +934,6 @@ pub mod test {
             } else {
                 self.consensus.bft_round_state.state_tag = StateTag::Follower;
             }
-
-            self.consensus
-                .bft_round_state
-                .consensus_proposal
-                .round_leader = cryptos.first().unwrap().validator_pubkey().clone();
         }
 
         pub fn setup_for_joining(&mut self, nodes: &[&ConsensusTestCtx]) {
@@ -1024,20 +1012,12 @@ pub mod test {
             slot: u64,
             view: u64,
         ) {
-            let leader_pubkey = nodes
-                .get(leader)
-                .unwrap()
-                .consensus
-                .crypto
-                .validator_pubkey()
-                .clone();
-
             // TODO: write a real one?
             let commit_qc = AggregateSignature::default();
 
             for (index, node) in nodes.iter_mut().enumerate() {
-                node.consensus.bft_round_state.consensus_proposal.slot = slot;
-                node.consensus.bft_round_state.consensus_proposal.view = view;
+                node.consensus.bft_round_state.slot = slot;
+                node.consensus.bft_round_state.view = view;
 
                 node.consensus
                     .bft_round_state
@@ -1051,11 +1031,6 @@ pub mod test {
                 } else {
                     node.consensus.bft_round_state.state_tag = StateTag::Follower;
                 }
-
-                node.consensus
-                    .bft_round_state
-                    .consensus_proposal
-                    .round_leader = leader_pubkey.clone();
             }
         }
 
@@ -1233,13 +1208,13 @@ pub mod test {
         node1.start_round().await;
         // Slot 0 - leader = node1
 
-        let (cp1, ticket1) = simple_commit_round! {
+        let (cp1, ticket1, view1) = simple_commit_round! {
             leader: node1,
             followers: [node2]
         };
 
         assert_eq!(cp1.slot, 1);
-        assert_eq!(cp1.view, 0);
+        assert_eq!(view1, 0);
         assert_eq!(
             cp1.parent_hash,
             ConsensusProposalHash("genesis".to_string())
@@ -1249,26 +1224,26 @@ pub mod test {
         // Slot 1 - leader = node2
         node2.start_round().await;
 
-        let (cp2, ticket2) = simple_commit_round! {
+        let (cp2, ticket2, view2) = simple_commit_round! {
             leader: node2,
             followers: [node1]
         };
 
         assert_eq!(cp2.slot, 2);
-        assert_eq!(cp2.view, 0);
+        assert_eq!(view2, 0);
         assert_eq!(cp2.parent_hash, cp1.hashed());
         assert!(matches!(ticket2, Ticket::CommitQC(_)));
 
         // Slot 2 - leader = node1
         node1.start_round().await;
 
-        let (cp3, ticket3) = simple_commit_round! {
+        let (cp3, ticket3, view3) = simple_commit_round! {
             leader: node1,
             followers: [node2]
         };
 
         assert_eq!(cp3.slot, 3);
-        assert_eq!(cp3.view, 0);
+        assert_eq!(view3, 0);
         assert!(matches!(ticket3, Ticket::CommitQC(_)));
     }
 
@@ -1288,10 +1263,10 @@ pub mod test {
         broadcast! {
             description: "Leader - Prepare",
             from: node1, to: [node2, node3, node4],
-            message_matches: ConsensusNetMessage::Prepare(cp, ticket) => {
+            message_matches: ConsensusNetMessage::Prepare(cp, ticket, view) => {
                 cp_round = Some(cp.clone());
                 assert_eq!(cp.slot, 1);
-                assert_eq!(cp.view, 0);
+                assert_eq!(*view, 0);
                 assert_eq!(ticket, &Ticket::Genesis);
             }
         };
@@ -1348,9 +1323,7 @@ pub mod test {
             .sign_net_message(ConsensusNetMessage::Prepare(
                 ConsensusProposal {
                     slot: 2,
-                    view: 0,
                     timestamp: 123,
-                    round_leader: node1.pubkey(),
                     cut: vec![(
                         LaneId(node2.pubkey()),
                         DataProposalHash("test".to_string()),
@@ -1361,6 +1334,7 @@ pub mod test {
                     parent_hash: ConsensusProposalHash("hash".into()),
                 },
                 Ticket::Genesis,
+                0,
             ))
             .expect("Error while signing");
 
@@ -1389,8 +1363,6 @@ pub mod test {
             .sign_net_message(ConsensusNetMessage::Prepare(
                 ConsensusProposal {
                     slot: 1,
-                    view: 0,
-                    round_leader: node1.pubkey(),
                     timestamp: 123,
                     cut: vec![(
                         LaneId(node2.pubkey()),
@@ -1402,6 +1374,7 @@ pub mod test {
                     parent_hash: ConsensusProposalHash("hash".into()),
                 },
                 Ticket::Genesis,
+                0,
             ))
             .expect("Error while signing");
 
@@ -1439,9 +1412,7 @@ pub mod test {
             .sign_net_message(ConsensusNetMessage::Prepare(
                 ConsensusProposal {
                     slot: 1,
-                    view: 0,
                     timestamp: 123,
-                    round_leader: node3.pubkey(),
                     cut: vec![(
                         LaneId(node2.pubkey()),
                         DataProposalHash("test".to_string()),
@@ -1452,6 +1423,7 @@ pub mod test {
                     parent_hash: ConsensusProposalHash("hash".into()),
                 },
                 Ticket::Genesis,
+                0,
             ))
             .expect("Error while signing");
 
@@ -1487,7 +1459,7 @@ pub mod test {
 
         node1.start_round_at(1000).await;
 
-        let (cp, _) = simple_commit_round! {
+        let (cp, ..) = simple_commit_round! {
             leader: node1,
             followers: [node2, node3, node4]
         };
@@ -1499,13 +1471,13 @@ pub mod test {
         broadcast! {
             description: "Leader Node2 second round",
             from: node2, to: [],
-            message_matches: ConsensusNetMessage::Prepare(next_cp, next_ticket) => {
+            message_matches: ConsensusNetMessage::Prepare(next_cp, next_ticket, cp_view) => {
 
                 assert_eq!(next_cp.timestamp, 900);
 
                 let prepare_msg = node2
                     .consensus
-                    .sign_net_message(ConsensusNetMessage::Prepare(next_cp.clone(), next_ticket.clone()))
+                    .sign_net_message(ConsensusNetMessage::Prepare(next_cp.clone(), next_ticket.clone(), *cp_view))
                     .unwrap();
 
                 assert_contains!(
@@ -1536,7 +1508,7 @@ pub mod test {
 
         node1.start_round_at(1000).await;
 
-        let (cp, _) = simple_commit_round! {
+        let (cp, ..) = simple_commit_round! {
             leader: node1,
             followers: [node2, node3, node4]
         };
@@ -1546,36 +1518,36 @@ pub mod test {
         node2.start_round_at(3000).await;
 
         assert_eq!(
-            node1.consensus.bft_round_state.consensus_proposal.timestamp,
+            node1.consensus.bft_round_state.current_proposal.timestamp,
             1000
         );
         assert_eq!(
-            node3.consensus.bft_round_state.consensus_proposal.timestamp,
+            node3.consensus.bft_round_state.current_proposal.timestamp,
             1000
         );
         assert_eq!(
-            node4.consensus.bft_round_state.consensus_proposal.timestamp,
+            node4.consensus.bft_round_state.current_proposal.timestamp,
             1000
         );
 
         broadcast! {
             description: "Leader Node2 second round",
             from: node2, to: [node1, node3, node4],
-            message_matches: ConsensusNetMessage::Prepare(next_cp, _) => {
+            message_matches: ConsensusNetMessage::Prepare(next_cp, ..) => {
                 assert_eq!(next_cp.timestamp, 3000);
             }
         };
 
         assert_eq!(
-            node1.consensus.bft_round_state.consensus_proposal.timestamp,
+            node1.consensus.bft_round_state.current_proposal.timestamp,
             3000
         );
         assert_eq!(
-            node3.consensus.bft_round_state.consensus_proposal.timestamp,
+            node3.consensus.bft_round_state.current_proposal.timestamp,
             3000
         );
         assert_eq!(
-            node4.consensus.bft_round_state.consensus_proposal.timestamp,
+            node4.consensus.bft_round_state.current_proposal.timestamp,
             3000
         );
     }
@@ -1598,13 +1570,13 @@ pub mod test {
         // Slot 1 - leader = node1
         // Ensuring one slot commits correctly before a timeout
 
-        let (cp, ticket) = simple_commit_round! {
+        let (cp, ticket, cp_view) = simple_commit_round! {
             leader: node1,
             followers: [node2, node3, node4]
         };
 
         assert_eq!(cp.slot, 1);
-        assert_eq!(cp.view, 0);
+        assert_eq!(cp_view, 0);
         assert!(matches!(ticket, Ticket::Genesis));
     }
 
@@ -1656,14 +1628,14 @@ pub mod test {
         node2.start_round().await;
 
         // Slot 2 view 1 (following a timeout round)
-        let (cp, ticket) = simple_commit_round! {
+        let (cp, ticket, cp_view) = simple_commit_round! {
           leader: node2,
           followers: [node1, node3, node4]
         };
 
         assert!(matches!(ticket, Ticket::TimeoutQC(_)));
         assert_eq!(cp.slot, 1);
-        assert_eq!(cp.view, 1);
+        assert_eq!(cp_view, 1);
         assert_eq!(cp.parent_hash, ConsensusProposalHash("genesis".into()));
     }
 
@@ -1724,14 +1696,14 @@ pub mod test {
         node2.start_round().await;
 
         // Slot 2 view 1 (following a timeout round)
-        let (cp, ticket) = simple_commit_round! {
+        let (cp, ticket, cp_view) = simple_commit_round! {
           leader: node2,
           followers: [node1, node3, node4]
         };
 
         assert!(matches!(ticket, Ticket::TimeoutQC(_)));
         assert_eq!(cp.slot, 1);
-        assert_eq!(cp.view, 1);
+        assert_eq!(cp_view, 1);
         assert_eq!(cp.parent_hash, ConsensusProposalHash("genesis".into()));
     }
 
@@ -1825,14 +1797,14 @@ pub mod test {
         node2.start_round().await;
 
         // Slot 2 view 1 (following a timeout round)
-        let (cp, ticket) = simple_commit_round! {
+        let (cp, ticket, cp_view) = simple_commit_round! {
           leader: node2,
           followers: [node1, node3, node4]
         };
 
         assert!(matches!(ticket, Ticket::TimeoutQC(_)));
         assert_eq!(cp.slot, 1);
-        assert_eq!(cp.view, 1);
+        assert_eq!(cp_view, 1);
         assert_eq!(cp.parent_hash, ConsensusProposalHash("genesis".into()));
     }
 
@@ -1899,14 +1871,14 @@ pub mod test {
         node2.start_round().await;
 
         // Slot 2 view 1 (following a timeout round)
-        let (cp, ticket) = simple_commit_round! {
+        let (cp, ticket, cp_view) = simple_commit_round! {
           leader: node2,
           followers: [node1, node3, node4, node5]
         };
 
         assert!(matches!(ticket, Ticket::TimeoutQC(_)));
         assert_eq!(cp.slot, 1);
-        assert_eq!(cp.view, 1);
+        assert_eq!(cp_view, 1);
         assert_eq!(cp.parent_hash, ConsensusProposalHash("genesis".into()));
     }
 
@@ -1968,9 +1940,9 @@ pub mod test {
             description: "Follower - Timeout Certificate to next leader",
             from: node5, to: [node2],
             message_matches: ConsensusNetMessage::TimeoutCertificate(_, slot, view) => {
-                if let ConsensusNetMessage::Prepare(cp, ticket) = lost_prepare {
+                if let ConsensusNetMessage::Prepare(cp, ticket, prep_view) = lost_prepare {
                     assert_eq!(&cp.slot, slot);
-                    assert_eq!(&cp.view, view);
+                    assert_eq!(&prep_view, view);
                     assert_eq!(ticket, Ticket::Genesis);
                 }
             }
@@ -1984,13 +1956,13 @@ pub mod test {
 
         node2.start_round().await;
 
-        let (cp, ticket) = simple_commit_round! {
+        let (cp, ticket, cp_view) = simple_commit_round! {
             leader: node2,
             followers: [node1, node3, node4, node5, node6, node7]
         };
 
         assert_eq!(cp.slot, 1);
-        assert_eq!(cp.view, 1);
+        assert_eq!(cp_view, 1);
         assert!(matches!(ticket, Ticket::TimeoutQC(_)));
         assert_eq!(cp.parent_hash, ConsensusProposalHash("genesis".into()));
     }
@@ -2008,13 +1980,13 @@ pub mod test {
         {
             node1.start_round().await;
 
-            let (cp, ticket) = simple_commit_round! {
+            let (cp, ticket, cp_view) = simple_commit_round! {
                 leader: node1,
                 followers: [node2]
             };
 
             assert_eq!(cp.slot, 1);
-            assert_eq!(cp.view, 0);
+            assert_eq!(cp_view, 0);
             assert!(matches!(ticket, Ticket::Genesis));
         }
 
@@ -2098,7 +2070,7 @@ pub mod test {
             broadcast! {
                 description: "Leader Proposal",
                 from: node2, to: [node1, node3],
-                message_matches: ConsensusNetMessage::Prepare(_, _) => {
+                message_matches: ConsensusNetMessage::Prepare(..) => {
                     assert_eq!(node2.consensus.bft_round_state.staking.bonded().len(), 2);
                 }
             };
@@ -2127,7 +2099,7 @@ pub mod test {
             info!("➡️  Leader proposal");
             node3.start_round().await;
 
-            let (cp, _) = simple_commit_round! {
+            let (cp, ..) = simple_commit_round! {
                 leader: node3,
                 followers: [node1, node2]
             };
@@ -2135,9 +2107,9 @@ pub mod test {
             assert_eq!(node2.consensus.bft_round_state.staking.bonded().len(), 3);
         }
 
-        assert_eq!(node1.consensus.bft_round_state.consensus_proposal.slot, 6);
-        assert_eq!(node2.consensus.bft_round_state.consensus_proposal.slot, 6);
-        assert_eq!(node3.consensus.bft_round_state.consensus_proposal.slot, 6);
+        assert_eq!(node1.consensus.bft_round_state.slot, 6);
+        assert_eq!(node2.consensus.bft_round_state.slot, 6);
+        assert_eq!(node3.consensus.bft_round_state.slot, 6);
     }
 
     bus_client! {

--- a/src/consensus/role_follower.rs
+++ b/src/consensus/role_follower.rs
@@ -153,17 +153,6 @@ impl FollowerRole for Consensus {
 
         // TODO: check we haven't voted for a proposal this slot/view already.
 
-        // Validate message comes from the correct leader
-        // (can't do this earlier as might need to process the ticket first)
-        let round_leader = self.round_leader()?;
-        if sender != round_leader {
-            self.metrics.prepare_error("wrong_leader");
-            bail!(
-                "Prepare consensus message for {} {} does not come from current leader {}. I won't vote for it.",
-                self.bft_round_state.slot, self.bft_round_state.view, round_leader
-            );
-        }
-
         // Sanity check: after processing the ticket, we should be in the right slot/view.
         // TODO: these checks are almost entirely redundant at this point because we process the ticket above.
         if consensus_proposal.slot != self.bft_round_state.slot {
@@ -173,6 +162,17 @@ impl FollowerRole for Consensus {
         if view != self.bft_round_state.view {
             self.metrics.prepare_error("wrong_view");
             bail!("Prepare message received for wrong view");
+        }
+
+        // Validate message comes from the correct leader
+        // (can't do this earlier as might need to process the ticket first)
+        let round_leader = self.round_leader()?;
+        if sender != round_leader {
+            self.metrics.prepare_error("wrong_leader");
+            bail!(
+                "Prepare consensus message for {} {} does not come from current leader {}. I won't vote for it.",
+                self.bft_round_state.slot, self.bft_round_state.view, round_leader
+            );
         }
 
         self.verify_poda(&consensus_proposal)?;

--- a/src/consensus/role_leader.rs
+++ b/src/consensus/role_leader.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Context, Result};
 use borsh::{BorshDeserialize, BorshSerialize};
-use hyle_model::ConsensusStakingAction;
+use hyle_model::{ConsensusProposal, ConsensusStakingAction};
 use staking::state::MIN_STAKE;
 use tracing::{debug, error, trace};
 
@@ -58,7 +58,13 @@ impl LeaderRole for Consensus {
         }
 
         if !self.is_round_leader() {
-            bail!("I'm not the leader for this slot");
+            bail!(
+                "I ({}) am not the leader for slot {} view {}, expected {}",
+                self.crypto.validator_pubkey(),
+                self.bft_round_state.slot,
+                self.bft_round_state.view,
+                self.round_leader()?,
+            );
         }
 
         let ticket = self
@@ -80,8 +86,9 @@ impl LeaderRole for Consensus {
         });
 
         debug!(
-            "🚀 Starting new slot {} with {} existing validators and {} candidates",
-            self.bft_round_state.consensus_proposal.slot,
+            "🚀 Starting new slot {} (view {}) with {} existing validators and {} candidates",
+            self.bft_round_state.slot,
+            self.bft_round_state.view,
             self.bft_round_state.staking.bonded().len(),
             new_validators_to_bond.len()
         );
@@ -108,7 +115,7 @@ impl LeaderRole for Consensus {
                     "Could not get a new cut from Mempool {:?}. Reusing previous one...",
                     err
                 );
-                self.bft_round_state.last_cut.clone()
+                self.bft_round_state.last_cut_seen.clone()
             }
         };
 
@@ -128,13 +135,18 @@ impl LeaderRole for Consensus {
         }
 
         // Start Consensus with following cut
-        self.bft_round_state.consensus_proposal.cut = cut;
-        self.bft_round_state.consensus_proposal.staking_actions = staking_actions;
-        self.bft_round_state.consensus_proposal.timestamp = current_timestamp;
+        self.bft_round_state.current_proposal = ConsensusProposal {
+            slot: self.bft_round_state.slot,
+            cut,
+            staking_actions,
+            timestamp: current_timestamp,
+            parent_hash: self.bft_round_state.parent_hash.clone(),
+        };
         let prepare = (
             self.crypto.validator_pubkey().clone(),
-            self.bft_round_state.consensus_proposal.clone(),
+            self.bft_round_state.current_proposal.clone(),
             ticket.clone(),
+            self.bft_round_state.view,
         );
         self.follower_state().buffered_prepares.push(prepare);
 
@@ -144,12 +156,13 @@ impl LeaderRole for Consensus {
 
         // Broadcasts Prepare message to all validators
         debug!(
-            proposal_hash = %self.bft_round_state.consensus_proposal.hashed(),
-            "🌐 Slot {} started. Broadcasting Prepare message", self.bft_round_state.consensus_proposal.slot,
+            proposal_hash = %self.bft_round_state.current_proposal.hashed(),
+            "🌐 Slot {} started. Broadcasting Prepare message", self.bft_round_state.slot,
         );
         self.broadcast_net_message(ConsensusNetMessage::Prepare(
-            self.bft_round_state.consensus_proposal.clone(),
+            self.bft_round_state.current_proposal.clone(),
             ticket,
+            self.bft_round_state.view,
         ))?;
 
         Ok(())
@@ -184,7 +197,7 @@ impl LeaderRole for Consensus {
 
         // Verify that the PrepareVote is for the correct proposal.
         // This also checks slot/view as those are part of the hash.
-        if consensus_proposal_hash != self.bft_round_state.consensus_proposal.hashed() {
+        if consensus_proposal_hash != self.bft_round_state.current_proposal.hashed() {
             self.metrics.prepare_vote_error("invalid_proposal_hash");
             bail!("PrepareVote has not received valid consensus proposal hash");
         }
@@ -214,7 +227,7 @@ impl LeaderRole for Consensus {
 
         debug!(
             "📩 Slot {} validated votes: {} / {} ({} validators for a total bond = {})",
-            self.bft_round_state.consensus_proposal.slot,
+            self.bft_round_state.slot,
             voting_power,
             2 * f + 1,
             self.bft_round_state.staking.bonded().len(),
@@ -226,7 +239,7 @@ impl LeaderRole for Consensus {
             let aggregates: &Vec<&SignedByValidator<ConsensusNetMessage>> =
                 &self.bft_round_state.leader.prepare_votes.iter().collect();
 
-            let proposal_hash_hint = self.bft_round_state.consensus_proposal.hashed();
+            let proposal_hash_hint = self.bft_round_state.current_proposal.hashed();
             // Aggregates them into a *Prepare* Quorum Certificate
             let prepvote_signed_aggregation = self.crypto.sign_aggregate(
                 ConsensusNetMessage::PrepareVote(proposal_hash_hint.clone()),
@@ -244,7 +257,7 @@ impl LeaderRole for Consensus {
             // Broadcast the *Prepare* Quorum Certificate to all validators
             debug!(
                 "Slot {} PrepareVote message validated. Broadcasting Confirm",
-                self.bft_round_state.consensus_proposal.slot
+                self.bft_round_state.slot
             );
             self.broadcast_net_message(ConsensusNetMessage::Confirm(
                 prepvote_signed_aggregation.signature,
@@ -281,13 +294,13 @@ impl LeaderRole for Consensus {
         }
 
         // Verify that the ConfirmAck is for the correct proposal
-        if consensus_proposal_hash != self.bft_round_state.consensus_proposal.hashed() {
+        if consensus_proposal_hash != self.bft_round_state.current_proposal.hashed() {
             self.metrics.confirm_ack_error("invalid_proposal_hash");
             debug!(
                 sender = %msg.signature.validator,
                 "Got {} expected {}",
                 consensus_proposal_hash,
-                self.bft_round_state.consensus_proposal.hashed()
+                self.bft_round_state.current_proposal.hashed()
             );
             bail!("ConfirmAck got invalid consensus proposal hash");
         }
@@ -319,7 +332,7 @@ impl LeaderRole for Consensus {
 
         debug!(
             "✅ Slot {} confirmed acks: {} / {} ({} validators for a total bond = {})",
-            self.bft_round_state.consensus_proposal.slot,
+            self.bft_round_state.slot,
             voting_power,
             2 * f + 1,
             self.bft_round_state.staking.bonded().len(),
@@ -335,7 +348,7 @@ impl LeaderRole for Consensus {
 
             // Aggregates them into a *Commit* Quorum Certificate
             let commit_signed_aggregation = self.crypto.sign_aggregate(
-                ConsensusNetMessage::ConfirmAck(self.bft_round_state.consensus_proposal.hashed()),
+                ConsensusNetMessage::ConfirmAck(self.bft_round_state.current_proposal.hashed()),
                 aggregates,
             )?;
 
@@ -353,7 +366,7 @@ impl LeaderRole for Consensus {
             // Process the same locally.
             self.try_commit_current_proposal(
                 commit_quorum_certificate,
-                self.bft_round_state.consensus_proposal.hashed(),
+                self.bft_round_state.current_proposal.hashed(),
             )?;
         }
         // TODO(?): Update behaviour when having more ?

--- a/src/consensus/role_sync.rs
+++ b/src/consensus/role_sync.rs
@@ -40,12 +40,6 @@ impl RoleSync for Consensus {
 
     fn on_sync_reply(&mut self, prepare: Prepare) -> Result<()> {
         let (sender, proposal, ticket, view) = prepare;
-        // Ignore obviously old messages
-        if proposal.slot < self.bft_round_state.slot
-            || proposal.slot == self.bft_round_state.slot && view <= self.bft_round_state.view
-        {
-            return Ok(());
-        }
         self.on_prepare(sender, proposal, ticket, view)
     }
 }

--- a/src/genesis.rs
+++ b/src/genesis.rs
@@ -492,8 +492,6 @@ impl Genesis {
             },
             consensus_proposal: ConsensusProposal {
                 slot: 0,
-                view: 0,
-                round_leader: round_leader.clone(),
                 // TODO: genesis block should have a consistent, up-to-date timestamp
                 timestamp: 1735689600000, // 1st of Jan 25 for now
                 // TODO: We aren't actually storing the data proposal above, so we cannot store it here,

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1075,8 +1075,6 @@ pub mod test {
                         staking: self.mempool.staking.clone(),
                         consensus_proposal: model::ConsensusProposal {
                             slot,
-                            view: 0,
-                            round_leader: leader.clone(),
                             cut: cut.clone(),
                             staking_actions: vec![],
                             timestamp: 777,

--- a/src/mempool/block_construction.rs
+++ b/src/mempool/block_construction.rs
@@ -319,8 +319,6 @@ pub mod test {
                     staking: ctx.mempool.staking.clone(),
                     consensus_proposal: model::ConsensusProposal {
                         slot: 1,
-                        view: 0,
-                        round_leader: crypto2.validator_pubkey().clone(),
                         cut: cut1.clone(),
                         staking_actions: vec![],
                         timestamp: 777,
@@ -364,8 +362,6 @@ pub mod test {
                     staking: ctx.mempool.staking.clone(),
                     consensus_proposal: model::ConsensusProposal {
                         slot: 2,
-                        view: 0,
-                        round_leader: crypto2.validator_pubkey().clone(),
                         cut: cut2.clone(),
                         staking_actions: vec![],
                         timestamp: 888,

--- a/src/single_node_consensus.rs
+++ b/src/single_node_consensus.rs
@@ -179,9 +179,7 @@ impl SingleNodeConsensus {
         let new_slot = self.store.last_slot + 1;
         let consensus_proposal = ConsensusProposal {
             slot: new_slot,
-            view: 0,
             timestamp: get_current_timestamp_ms(),
-            round_leader: self.crypto.validator_pubkey().clone(),
             cut: self.store.last_cut.clone(),
             staking_actions: vec![],
             parent_hash: std::mem::take(&mut self.store.last_consensus_proposal_hash),

--- a/src/tests/autobahn_testing.rs
+++ b/src/tests/autobahn_testing.rs
@@ -129,12 +129,14 @@ macro_rules! simple_commit_round {
     (leader: $leader:expr, followers: [$($follower:expr),+]$(, joining: $joining:expr)?) => {{
         let round_consensus_proposal;
         let round_ticket;
+        let view: u64;
         broadcast! {
             description: "Leader - Prepare",
             from: $leader, to: [$($follower),+$(,$joining)?],
-            message_matches: hyle_contract_sdk::ConsensusNetMessage::Prepare(cp, ticket) => {
+            message_matches: hyle_contract_sdk::ConsensusNetMessage::Prepare(cp, ticket, prep_view) => {
                 round_consensus_proposal = cp.clone();
                 round_ticket = ticket.clone();
+                view = *prep_view;
             }
         };
 
@@ -147,7 +149,7 @@ macro_rules! simple_commit_round {
         broadcast! {
             description: "Leader - Confirm",
             from: $leader, to: [$($follower),+$(,$joining)?],
-            message_matches: hyle_contract_sdk::ConsensusNetMessage::Confirm(_, _)
+            message_matches: hyle_contract_sdk::ConsensusNetMessage::Confirm(..)
         };
 
         send! {
@@ -159,10 +161,10 @@ macro_rules! simple_commit_round {
         broadcast! {
             description: "Leader - Commit",
             from: $leader, to: [$($follower),+$(,$joining)?],
-            message_matches: hyle_contract_sdk::ConsensusNetMessage::Commit(_, _)
+            message_matches: hyle_contract_sdk::ConsensusNetMessage::Commit(..)
         };
 
-        (round_consensus_proposal, round_ticket)
+        (round_consensus_proposal, round_ticket, view)
     }};
 }
 
@@ -268,13 +270,16 @@ impl AutobahnTestCtx {
     }
 
     pub fn generate_cryptos(nb: usize) -> Vec<BlstCrypto> {
-        (0..nb)
+        let mut res: Vec<_> = (0..nb)
             .map(|i| {
                 let crypto = crypto::BlstCrypto::new(&format!("node-{i}")).unwrap();
                 info!("node {}: {}", i, crypto.validator_pubkey());
                 crypto
             })
-            .collect()
+            .collect();
+        // Staking currently sorts the bonded validators so do the same
+        res.sort_by_key(|c| c.validator_pubkey().clone());
+        res
     }
 
     /// Spawn a coroutine to answer the command response call of start_round, with the current current of mempool
@@ -365,7 +370,7 @@ async fn autobahn_basic_flow() {
     send! {
         description: "Disseminated Tx Vote",
         from: [node2.mempool_ctx, node3.mempool_ctx, node4.mempool_ctx], to: node1.mempool_ctx,
-        message_matches: MempoolNetMessage::DataVote(_, _)
+        message_matches: MempoolNetMessage::DataVote(..)
     };
 
     let data_proposal_hash_node1 = node1
@@ -387,7 +392,7 @@ async fn autobahn_basic_flow() {
     broadcast! {
         description: "Prepare",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(cp, _ticket) => {
+        message_matches: ConsensusNetMessage::Prepare(cp, ..) => {
             consensus_proposal = cp.clone();
             assert_eq!(
                 cp
@@ -424,7 +429,7 @@ async fn autobahn_basic_flow() {
     broadcast! {
         description: "Confirm",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     let (vote2, vote3, vote4) = send! {
@@ -449,7 +454,7 @@ async fn autobahn_basic_flow() {
     broadcast! {
         description: "Commit",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 }
 
@@ -491,7 +496,7 @@ async fn mempool_broadcast_multiple_data_proposals() {
     send! {
         description: "Disseminated Tx Vote",
         from: [node2.mempool_ctx, node3.mempool_ctx, node4.mempool_ctx], to: node1.mempool_ctx,
-        message_matches: MempoolNetMessage::DataVote(_, _)
+        message_matches: MempoolNetMessage::DataVote(..)
     };
 
     node1.mempool_ctx.assert_broadcast("poda update");
@@ -531,7 +536,7 @@ async fn mempool_broadcast_multiple_data_proposals() {
     send! {
         description: "Disseminated Tx Vote",
         from: [node2.mempool_ctx, node3.mempool_ctx, node4.mempool_ctx], to: node1.mempool_ctx,
-        message_matches: MempoolNetMessage::DataVote(_, _)
+        message_matches: MempoolNetMessage::DataVote(..)
     };
 }
 
@@ -581,7 +586,7 @@ async fn mempool_fail_to_vote_on_fork() {
     send! {
         description: "Disseminated Tx Vote",
         from: [node2.mempool_ctx, node3.mempool_ctx, node4.mempool_ctx], to: node1.mempool_ctx,
-        message_matches: MempoolNetMessage::DataVote(_, _)
+        message_matches: MempoolNetMessage::DataVote(..)
     };
 
     node1.mempool_ctx.assert_broadcast("poda update");
@@ -621,7 +626,7 @@ async fn mempool_fail_to_vote_on_fork() {
     send! {
         description: "Disseminated Tx Vote",
         from: [node2.mempool_ctx, node3.mempool_ctx, node4.mempool_ctx], to: node1.mempool_ctx,
-        message_matches: MempoolNetMessage::DataVote(_, _)
+        message_matches: MempoolNetMessage::DataVote(..)
     };
 
     // BASIC FORK
@@ -853,7 +858,7 @@ async fn protocol_fees() {
     send! {
         description: "Disseminated Tx Vote",
         from: [node2.mempool_ctx, node3.mempool_ctx, node4.mempool_ctx], to: node1.mempool_ctx,
-        message_matches: MempoolNetMessage::DataVote(_, _)
+        message_matches: MempoolNetMessage::DataVote(..)
     };
 
     node1.mempool_ctx.assert_broadcast("poda update");
@@ -926,7 +931,7 @@ async fn protocol_fees() {
     send! {
         description: "Disseminated Tx Vote",
         from: [node1.mempool_ctx, node3.mempool_ctx, node4.mempool_ctx], to: node2.mempool_ctx,
-        message_matches: MempoolNetMessage::DataVote(_, _)
+        message_matches: MempoolNetMessage::DataVote(..)
     };
 
     let dp_size_2 = LaneBytesSize(dp.estimate_size() as u64);
@@ -969,10 +974,10 @@ async fn protocol_fees() {
     let prepare = broadcast! {
         description: "Prepare",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
     let cp = match prepare.msg {
-        ConsensusNetMessage::Prepare(cp, _ticket) => cp,
+        ConsensusNetMessage::Prepare(cp, ..) => cp,
         _ => panic!("Should be a Prepare"),
     };
 
@@ -980,15 +985,15 @@ async fn protocol_fees() {
     assert_eq!(
         cp.staking_actions[0],
         ConsensusStakingAction::PayFeesForDaDi {
-            lane_id: node2.mempool_ctx.own_lane(),
-            cumul_size: dp_size_2
+            lane_id: node1.mempool_ctx.own_lane(),
+            cumul_size: dp_size_1
         }
     );
     assert_eq!(
         cp.staking_actions[1],
         ConsensusStakingAction::PayFeesForDaDi {
-            lane_id: node1.mempool_ctx.own_lane(),
-            cumul_size: dp_size_1
+            lane_id: node2.mempool_ctx.own_lane(),
+            cumul_size: dp_size_2
         }
     );
 }
@@ -1013,7 +1018,7 @@ async fn autobahn_missed_a_confirm_message() {
             &mut node4.consensus_ctx,
         ],
         0,
-        3,
+        5,
         0,
     );
 
@@ -1023,7 +1028,7 @@ async fn autobahn_missed_a_confirm_message() {
     broadcast! {
         description: "Prepare",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1036,7 +1041,7 @@ async fn autobahn_missed_a_confirm_message() {
     broadcast! {
         description: "Confirm",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1049,16 +1054,16 @@ async fn autobahn_missed_a_confirm_message() {
     broadcast! {
         description: "Commit",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 
-    // SLot 2 starts with new leader, sending to all
+    // Slot 6 starts with new leader, sending to all
     node2.start_round_with_cut_from_mempool().await;
 
     broadcast! {
         description: "Prepare",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1070,7 +1075,7 @@ async fn autobahn_missed_a_confirm_message() {
     broadcast! {
         description: "Confirm",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1082,7 +1087,7 @@ async fn autobahn_missed_a_confirm_message() {
     broadcast! {
         description: "Commit",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 }
 
@@ -1106,7 +1111,7 @@ async fn autobahn_missed_confirm_and_commit_messages() {
             &mut node4.consensus_ctx,
         ],
         0,
-        3,
+        5,
         0,
     );
 
@@ -1115,7 +1120,7 @@ async fn autobahn_missed_confirm_and_commit_messages() {
     broadcast! {
         description: "Prepare - Slot from node-1 not yet sent to node 4",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1127,7 +1132,7 @@ async fn autobahn_missed_confirm_and_commit_messages() {
     broadcast! {
         description: "Confirm - Node 4 doesn't receive confirm",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1139,16 +1144,16 @@ async fn autobahn_missed_confirm_and_commit_messages() {
     broadcast! {
         description: "Commit - Node 4 doesn't receive commit",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 
-    // SLot 2 starts with new leader, sending to all
+    // Slot 6 starts with new leader, sending to all
     node2.start_round_with_cut_from_mempool().await;
 
     broadcast! {
         description: "Prepare",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1160,7 +1165,7 @@ async fn autobahn_missed_confirm_and_commit_messages() {
     broadcast! {
         description: "Confirm",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1172,7 +1177,7 @@ async fn autobahn_missed_confirm_and_commit_messages() {
     broadcast! {
         description: "Commit",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 }
 
@@ -1189,17 +1194,17 @@ async fn autobahn_buffer_early_messages() {
             &mut node4.consensus_ctx,
         ],
         0,
-        3,
+        5,
         0,
     );
 
-    // Slot 3 starts, all nodes receive the prepare
+    // Slot 5 starts, all nodes receive the prepare
     node1.start_round_with_cut_from_mempool().await;
 
     broadcast! {
         description: "Prepare",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1211,7 +1216,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Confirm - Node4 disconnected",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1223,7 +1228,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Commit - Node4 still disconnected",
         from: node1.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 
     // Slot 4 starts with new leader with node4 disconnected
@@ -1232,7 +1237,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Prepare",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1244,7 +1249,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Confirm",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1256,7 +1261,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Commit",
         from: node2.consensus_ctx, to: [node1.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 
     // Slot 5 starts with new leader but node4 is back online
@@ -1265,7 +1270,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Prepare",
         from: node3.consensus_ctx, to: [node1.consensus_ctx, node2.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1316,7 +1321,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Commit",
         from: node3.consensus_ctx, to: [node1.consensus_ctx, node2.consensus_ctx, node4.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 
     // Slot 6 starts with node4 as leader
@@ -1325,7 +1330,7 @@ async fn autobahn_buffer_early_messages() {
     broadcast! {
         description: "Prepare",
         from: node4.consensus_ctx, to: [node1.consensus_ctx, node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 }
 
@@ -1342,17 +1347,17 @@ async fn autobahn_got_timed_out_during_sync() {
             &mut node3.consensus_ctx,
         ],
         0,
-        3,
+        5,
         0,
     );
 
-    // Slot 3 starts, all nodes receive the prepare
+    // Slot 5 starts, all nodes receive the prepare
     node0.start_round_with_cut_from_mempool().await;
 
     broadcast! {
         description: "Prepare",
         from: node0.consensus_ctx, to: [node1.consensus_ctx, node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1364,7 +1369,7 @@ async fn autobahn_got_timed_out_during_sync() {
     broadcast! {
         description: "Confirm - Node1 disconnected",
         from: node0.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1376,7 +1381,7 @@ async fn autobahn_got_timed_out_during_sync() {
     broadcast! {
         description: "Commit - Node1 still disconnected",
         from: node0.consensus_ctx, to: [node2.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 
     // Make node0 and node2 timeout, node3 will not timeout but follow mutiny
@@ -1412,13 +1417,13 @@ async fn autobahn_got_timed_out_during_sync() {
         .consensus_ctx
         .assert_broadcast("Timeout Certificate 4");
 
-    // Slot 4 starts with new leader with node2 disconnected
+    // Slot 6 starts with new leader with node1 disconnected
     node2.start_round_with_cut_from_mempool().await;
 
     broadcast! {
         description: "Prepare",
         from: node2.consensus_ctx, to: [node0.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
@@ -1430,7 +1435,7 @@ async fn autobahn_got_timed_out_during_sync() {
     broadcast! {
         description: "Confirm",
         from: node2.consensus_ctx, to: [node0.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Confirm(_, _)
+        message_matches: ConsensusNetMessage::Confirm(..)
     };
 
     send! {
@@ -1442,29 +1447,29 @@ async fn autobahn_got_timed_out_during_sync() {
     broadcast! {
         description: "Commit",
         from: node2.consensus_ctx, to: [node0.consensus_ctx, node3.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 
-    // Slot 5 starts with new leader but node1 is back online
-    node3.start_round_with_cut_from_mempool().await;
+    // Slot 5 starts but node1 is back online - leader is again node2
+    node2.start_round_with_cut_from_mempool().await;
 
     broadcast! {
         description: "Prepare",
-        from: node3.consensus_ctx, to: [node0.consensus_ctx, node1.consensus_ctx, node2.consensus_ctx],
-        message_matches: ConsensusNetMessage::Prepare(_, _)
+        from: node2.consensus_ctx, to: [node0.consensus_ctx, node1.consensus_ctx, node3.consensus_ctx],
+        message_matches: ConsensusNetMessage::Prepare(..)
     };
 
     send! {
         description: "PrepareVote",
-        from: [node0.consensus_ctx, node2.consensus_ctx], to: node3.consensus_ctx,
+        from: [node0.consensus_ctx, node3.consensus_ctx], to: node2.consensus_ctx,
         message_matches: ConsensusNetMessage::PrepareVote(_)
     };
 
-    let confirm = node3.consensus_ctx.assert_broadcast("Confirm");
+    let confirm = node2.consensus_ctx.assert_broadcast("Confirm");
 
     broadcast! {
         description: "SyncRequest - Node1 ask for missed proposal Slot 4",
-        from: node1.consensus_ctx, to: [node0.consensus_ctx, node2.consensus_ctx, node3.consensus_ctx],
+        from: node1.consensus_ctx, to: [node0.consensus_ctx, node3.consensus_ctx, node2.consensus_ctx],
         message_matches: ConsensusNetMessage::SyncRequest(_)
     };
 
@@ -1475,33 +1480,33 @@ async fn autobahn_got_timed_out_during_sync() {
     };
 
     send! {
-        description: "PrepareVote - Node2 votes on slot 5",
-        from: [node1.consensus_ctx], to: node3.consensus_ctx,
+        description: "PrepareVote - Node1 votes on slot 7",
+        from: [node1.consensus_ctx], to: node2.consensus_ctx,
         message_matches: ConsensusNetMessage::PrepareVote(_)
     };
 
     node0.consensus_ctx.handle_msg(
         &confirm,
-        "[handling broadcast message from: node3 at: node0] Confirm",
+        "[handling broadcast message from: node2 at: node0] Confirm",
     );
     node1.consensus_ctx.handle_msg(
         &confirm,
-        "[handling broadcast message from: node3 at: node1] Confirm",
+        "[handling broadcast message from: node2 at: node1] Confirm",
     );
-    node2.consensus_ctx.handle_msg(
+    node3.consensus_ctx.handle_msg(
         &confirm,
-        "[handling broadcast message from: node3 at: node2] Confirm",
+        "[handling broadcast message from: node2 at: node3] Confirm",
     );
 
     send! {
         description: "ConfirmAck",
-        from: [node0.consensus_ctx, node1.consensus_ctx, node2.consensus_ctx], to: node3.consensus_ctx,
+        from: [node0.consensus_ctx, node1.consensus_ctx, node3.consensus_ctx], to: node2.consensus_ctx,
         message_matches: ConsensusNetMessage::ConfirmAck(_)
     };
 
     broadcast! {
         description: "Commit",
-        from: node3.consensus_ctx, to: [node0.consensus_ctx, node1.consensus_ctx, node2.consensus_ctx],
-        message_matches: ConsensusNetMessage::Commit(_, _)
+        from: node2.consensus_ctx, to: [node0.consensus_ctx, node1.consensus_ctx, node3.consensus_ctx],
+        message_matches: ConsensusNetMessage::Commit(..)
     };
 }


### PR DESCRIPTION
- Move slot/view to the bft_round_state object to reflect that this is 'trusted state'
- Making consensus_proposal the `current_proposal` we are examining, which can be replaced without breaking assumptions, clarifying the code in finish_round a bit
- Remove round_leader because we need two round robins - one for views, one for slots.
