### PR TITLE
🐛 Drop Peer for duplicate connection

### DIFF
--- a/src/p2p/network.rs
+++ b/src/p2p/network.rs
@@ -16,6 +16,11 @@ pub struct Hello {
     pub da_address: String,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, BorshSerialize, BorshDeserialize, Eq, PartialEq)]
+pub struct Verack {
+    pub version: u16,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum OutboundMessage {
     SendMessage {
@@ -99,7 +104,7 @@ pub enum NetMessage {
 #[derive(Debug, Serialize, Deserialize, Clone, BorshSerialize, BorshDeserialize, Eq, PartialEq)]
 pub enum HandshakeNetMessage {
     Hello(SignedByValidator<Hello>),
-    Verack,
+    Verack(SignedByValidator<Verack>),
     Ping,
     Pong,
 }


### PR DESCRIPTION
[NOT A WORKING SOLUTION]
It's not actually working. When the node gets disconnected and drops all conenctions, the other nodes keep their Peer  for that node alive. Thus no new connection can be done. 
Fixes https://github.com/Hyle-org/hyle/issues/902
