### PR TITLE
⚡️ Split DP & metadata (signatures, ...) in mempool storage.

### DIFF
--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -34,7 +34,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use storage::{LaneEntry, Storage};
+use storage::{LaneEntryMetadata, Storage};
 use tokio::task::{JoinHandle, JoinSet};
 use verify_tx::DataProposalVerdict;
 // Pick one of the two implementations
@@ -161,7 +161,7 @@ pub enum MempoolNetMessage {
     DataVote(DataProposalHash, LaneBytesSize), // New lane size with this DP
     PoDAUpdate(DataProposalHash, Vec<SignedByValidator<MempoolNetMessage>>),
     SyncRequest(Option<DataProposalHash>, Option<DataProposalHash>),
-    SyncReply(Vec<LaneEntry>),
+    SyncReply(Vec<(LaneEntryMetadata, DataProposal)>),
 }
 
 impl Display for MempoolNetMessage {
@@ -449,7 +449,7 @@ impl Mempool {
         }
 
         let validator = &msg.signature.validator;
-        // TODO: adapt can_rejoin test to emit a stake tx before turning on the joining node
+        // TODO: adapt can_rejoin test to emit a stake tx before turning on the joining node
         // if !self.validators.contains(validator) {
         //     bail!(
         //         "Received {} message from unknown validator {validator}. Only accepting {:?}",
@@ -477,8 +477,8 @@ impl Mempool {
                     to_data_proposal_hash.as_ref(),
                 )?;
             }
-            MempoolNetMessage::SyncReply(lane_entries) => {
-                self.on_sync_reply(validator, lane_entries)?;
+            MempoolNetMessage::SyncReply(missing_entries) => {
+                self.on_sync_reply(validator, missing_entries)?;
             }
         }
         Ok(())
@@ -487,7 +487,7 @@ impl Mempool {
     fn on_sync_reply(
         &mut self,
         sender_validator: &ValidatorPublicKey,
-        missing_lane_entries: Vec<LaneEntry>,
+        missing_entries: Vec<(LaneEntryMetadata, DataProposal)>,
     ) -> Result<()> {
         trace!("SyncReply from validator {sender_validator}");
 
@@ -496,13 +496,11 @@ impl Mempool {
         let lane_operator = self.get_lane_operator(lane_id);
 
         // Ensure all lane entries are signed by the validator.
-        if missing_lane_entries.iter().any(|lane_entry| {
-            let expected_message = MempoolNetMessage::DataVote(
-                lane_entry.data_proposal.hashed(),
-                lane_entry.cumul_size,
-            );
+        if missing_entries.iter().any(|(metadata, data_proposal)| {
+            let expected_message =
+                MempoolNetMessage::DataVote(data_proposal.hashed(), metadata.cumul_size);
 
-            !lane_entry
+            !metadata
                 .signatures
                 .iter()
                 .any(|s| &s.signature.validator == lane_operator && s.msg == expected_message)
@@ -514,29 +512,29 @@ impl Mempool {
         }
 
         // If we end up with an empty list, return an error (for testing/logic)
-        if missing_lane_entries.is_empty() {
+        if missing_entries.is_empty() {
             bail!("Empty lane entries after filtering out missing signatures");
         }
 
         // Add missing lanes to the validator's lane
         debug!(
             "Filling hole with {} entries for {lane_id}",
-            missing_lane_entries.len()
+            missing_entries.len()
         );
 
         // Assert that missing lane entries are in the right order
-        for window in missing_lane_entries.windows(2) {
-            let first_hash = window.first().map(|le| le.data_proposal.hashed());
+        for window in missing_entries.windows(2) {
+            let first_hash = window.first().map(|(_, dp)| dp.hashed());
             let second_parent_hash = window
                 .get(1)
-                .and_then(|le| le.data_proposal.parent_data_proposal_hash.as_ref());
+                .and_then(|(_, dp)| dp.parent_data_proposal_hash.as_ref());
             if first_hash.as_ref() != second_parent_hash {
                 bail!("Lane entries are not in the right order");
             }
         }
 
         // SyncReply only comes for missing data proposals. We should NEVER update the lane tip
-        for lane_entry in missing_lane_entries {
+        for lane_entry in missing_entries {
             self.lanes
                 .put_no_verification(lane_id.clone(), lane_entry)?;
         }
@@ -573,7 +571,7 @@ impl Mempool {
             to_data_proposal_hash
         );
 
-        let missing_lane_entries = self.lanes.get_lane_entries_between_hashes(
+        let missing_lane_entries = self.lanes.get_entries_between_hashes(
             &self.own_lane_id(),
             from_data_proposal_hash,
             to_data_proposal_hash,
@@ -670,7 +668,7 @@ impl Mempool {
     fn send_sync_reply(
         &mut self,
         validator: &ValidatorPublicKey,
-        lane_entries: Vec<LaneEntry>,
+        lane_entries: Vec<(LaneEntryMetadata, DataProposal)>,
     ) -> Result<()> {
         // cleanup previously tracked sent sync request
         self.metrics.add_sync_reply(
@@ -1008,65 +1006,30 @@ pub mod test {
                 .map(|(_, s)| s)
         }
 
-        pub fn last_lane_entry(&self, lane_id: &LaneId) -> (LaneEntry, DataProposalHash) {
+        pub fn last_lane_entry(
+            &self,
+            lane_id: &LaneId,
+        ) -> ((LaneEntryMetadata, DataProposal), DataProposalHash) {
             let last_dp_hash = self.current_hash(lane_id).unwrap();
+            let last_metadata = self
+                .mempool
+                .lanes
+                .get_metadata_by_hash(lane_id, &last_dp_hash)
+                .unwrap()
+                .unwrap();
             let last_dp = self
                 .mempool
                 .lanes
-                .get_by_hash(lane_id, &last_dp_hash)
+                .get_dp_by_hash(lane_id, &last_dp_hash)
                 .unwrap()
                 .unwrap();
 
-            (last_dp, last_dp_hash.clone())
+            ((last_metadata, last_dp), last_dp_hash.clone())
         }
 
         pub fn current_size(&self) -> Option<LaneBytesSize> {
             let lane_id = LaneId(self.validator_pubkey().clone());
             self.current_size_of(&lane_id)
-        }
-
-        pub fn pop_data_proposal(&mut self) -> (DataProposal, DataProposalHash, LaneBytesSize) {
-            let lane_id = LaneId(self.validator_pubkey().clone());
-            self.pop_lane_data_proposal(&lane_id)
-        }
-
-        pub fn pop_lane_data_proposal(
-            &mut self,
-            lane_id: &LaneId,
-        ) -> (DataProposal, DataProposalHash, LaneBytesSize) {
-            // Get the latest lane entry
-            let latest_data_proposal_hash = self.current_hash(lane_id).unwrap();
-            let latest_lane_entry = self
-                .mempool
-                .lanes
-                .get_by_hash(lane_id, &latest_data_proposal_hash)
-                .unwrap()
-                .unwrap();
-
-            // update the tip
-            if let Some(parent_dp_hash) = latest_lane_entry
-                .data_proposal
-                .parent_data_proposal_hash
-                .as_ref()
-            {
-                self.mempool.lanes.lanes_tip.insert(
-                    lane_id.clone(),
-                    (parent_dp_hash.clone(), latest_lane_entry.cumul_size),
-                );
-            } else {
-                self.mempool.lanes.lanes_tip.remove(lane_id);
-            }
-
-            // Remove the lane entry from db
-            self.mempool
-                .lanes
-                .remove_lane_entry(lane_id, &latest_data_proposal_hash);
-
-            (
-                latest_lane_entry.data_proposal,
-                latest_data_proposal_hash,
-                latest_lane_entry.cumul_size,
-            )
         }
 
         pub fn push_data_proposal(&mut self, dp: DataProposal) {
@@ -1078,11 +1041,14 @@ pub mod test {
                 .lanes
                 .put_no_verification(
                     lane_id,
-                    LaneEntry {
-                        data_proposal: dp,
-                        cumul_size: size,
-                        signatures: vec![],
-                    },
+                    (
+                        LaneEntryMetadata {
+                            parent_data_proposal_hash: dp.parent_data_proposal_hash.clone(),
+                            cumul_size: size,
+                            signatures: vec![],
+                        },
+                        dp,
+                    ),
                 )
                 .unwrap();
         }
@@ -1206,9 +1172,7 @@ pub mod test {
         ctx.process_new_data_proposal(data_proposal.clone())?;
 
         // Since mempool is alone, no broadcast
-
-        let (LaneEntry { data_proposal, .. }, _) =
-            ctx.last_lane_entry(&LaneId(ctx.validator_pubkey().clone()));
+        let (..) = ctx.last_lane_entry(&LaneId(ctx.validator_pubkey().clone()));
 
         // Add new validator
         let crypto2 = BlstCrypto::new("2").unwrap();
@@ -1227,7 +1191,7 @@ pub mod test {
         match ctx.assert_send(crypto2.validator_pubkey(), "SyncReply").msg {
             MempoolNetMessage::SyncReply(lane_entries) => {
                 assert_eq!(lane_entries.len(), 1);
-                assert_eq!(lane_entries.first().unwrap().data_proposal, data_proposal);
+                assert_eq!(lane_entries.first().unwrap().1, data_proposal);
             }
             _ => panic!("Expected SyncReply message"),
         };
@@ -1250,16 +1214,19 @@ pub mod test {
         ctx.add_trusted_validator(crypto2.validator_pubkey());
 
         // First: the message is from crypto2, but the DP is not signed correctly
-        let signed_msg = crypto2.sign(MempoolNetMessage::SyncReply(vec![LaneEntry {
-            data_proposal: data_proposal.clone(),
-            cumul_size,
-            signatures: vec![crypto3
-                .sign(MempoolNetMessage::DataVote(
-                    data_proposal.hashed(),
-                    cumul_size,
-                ))
-                .expect("should sign")],
-        }]))?;
+        let signed_msg = crypto2.sign(MempoolNetMessage::SyncReply(vec![(
+            LaneEntryMetadata {
+                parent_data_proposal_hash: None,
+                cumul_size,
+                signatures: vec![crypto3
+                    .sign(MempoolNetMessage::DataVote(
+                        data_proposal.hashed(),
+                        cumul_size,
+                    ))
+                    .expect("should sign")],
+            },
+            data_proposal.clone(),
+        )]))?;
 
         let handle = ctx.mempool.handle_net_message(signed_msg.clone());
         assert_eq!(
@@ -1271,16 +1238,19 @@ pub mod test {
         );
 
         // Second: the message is NOT from crypto2, but the DP is signed by crypto2
-        let signed_msg = crypto3.sign(MempoolNetMessage::SyncReply(vec![LaneEntry {
-            data_proposal: data_proposal.clone(),
-            cumul_size,
-            signatures: vec![crypto2
-                .sign(MempoolNetMessage::DataVote(
-                    data_proposal.hashed(),
-                    cumul_size,
-                ))
-                .expect("should sign")],
-        }]))?;
+        let signed_msg = crypto3.sign(MempoolNetMessage::SyncReply(vec![(
+            LaneEntryMetadata {
+                parent_data_proposal_hash: None,
+                cumul_size,
+                signatures: vec![crypto2
+                    .sign(MempoolNetMessage::DataVote(
+                        data_proposal.hashed(),
+                        cumul_size,
+                    ))
+                    .expect("should sign")],
+            },
+            data_proposal.clone(),
+        )]))?;
 
         // This actually fails - we don't know how to handle it
         let handle = ctx.mempool.handle_net_message(signed_msg.clone());
@@ -1293,16 +1263,19 @@ pub mod test {
         );
 
         // Third: the message is from crypto2, the signature is from crypto2, but the message is wrong
-        let signed_msg = crypto3.sign(MempoolNetMessage::SyncReply(vec![LaneEntry {
-            data_proposal: data_proposal.clone(),
-            cumul_size,
-            signatures: vec![crypto2
-                .sign(MempoolNetMessage::DataVote(
-                    DataProposalHash("non_existent".to_owned()),
-                    cumul_size,
-                ))
-                .expect("should sign")],
-        }]))?;
+        let signed_msg = crypto3.sign(MempoolNetMessage::SyncReply(vec![(
+            LaneEntryMetadata {
+                parent_data_proposal_hash: None,
+                cumul_size,
+                signatures: vec![crypto2
+                    .sign(MempoolNetMessage::DataVote(
+                        DataProposalHash("non_existent".to_owned()),
+                        cumul_size,
+                    ))
+                    .expect("should sign")],
+            },
+            data_proposal.clone(),
+        )]))?;
 
         // This actually fails - we don't know how to handle it
         let handle = ctx.mempool.handle_net_message(signed_msg.clone());
@@ -1315,16 +1288,19 @@ pub mod test {
         );
 
         // Fourth: the message is from crypto2, the signature is from crypto2, but the size is wrong
-        let signed_msg = crypto2.sign(MempoolNetMessage::SyncReply(vec![LaneEntry {
-            data_proposal: data_proposal.clone(),
-            cumul_size: LaneBytesSize(0),
-            signatures: vec![crypto2
-                .sign(MempoolNetMessage::DataVote(
-                    data_proposal.hashed(),
-                    cumul_size,
-                ))
-                .expect("should sign")],
-        }]))?;
+        let signed_msg = crypto2.sign(MempoolNetMessage::SyncReply(vec![(
+            LaneEntryMetadata {
+                parent_data_proposal_hash: None,
+                cumul_size: LaneBytesSize(0),
+                signatures: vec![crypto2
+                    .sign(MempoolNetMessage::DataVote(
+                        data_proposal.hashed(),
+                        cumul_size,
+                    ))
+                    .expect("should sign")],
+            },
+            data_proposal.clone(),
+        )]))?;
 
         // This actually fails - we don't know how to handle it
         let handle = ctx.mempool.handle_net_message(signed_msg.clone());
@@ -1342,26 +1318,32 @@ pub mod test {
             vec![make_register_contract_tx(ContractName::new("test1"))],
         );
         let signed_msg = crypto2.sign(MempoolNetMessage::SyncReply(vec![
-            LaneEntry {
-                data_proposal: data_proposal.clone(),
-                cumul_size,
-                signatures: vec![crypto2
-                    .sign(MempoolNetMessage::DataVote(
-                        data_proposal.hashed(),
-                        cumul_size,
-                    ))
-                    .expect("should sign")],
-            },
-            LaneEntry {
-                data_proposal: incorrect_parent.clone(),
-                cumul_size,
-                signatures: vec![crypto2
-                    .sign(MempoolNetMessage::DataVote(
-                        incorrect_parent.hashed(),
-                        cumul_size,
-                    ))
-                    .expect("should sign")],
-            },
+            (
+                LaneEntryMetadata {
+                    parent_data_proposal_hash: None,
+                    cumul_size,
+                    signatures: vec![crypto2
+                        .sign(MempoolNetMessage::DataVote(
+                            data_proposal.hashed(),
+                            cumul_size,
+                        ))
+                        .expect("should sign")],
+                },
+                data_proposal.clone(),
+            ),
+            (
+                LaneEntryMetadata {
+                    parent_data_proposal_hash: Some(DataProposalHash("incorrect".to_owned())),
+                    cumul_size,
+                    signatures: vec![crypto2
+                        .sign(MempoolNetMessage::DataVote(
+                            incorrect_parent.hashed(),
+                            cumul_size,
+                        ))
+                        .expect("should sign")],
+                },
+                incorrect_parent.clone(),
+            ),
         ]))?;
 
         // This actually fails - we don't know how to handle it
@@ -1370,17 +1352,21 @@ pub mod test {
             handle.expect_err("should fail").to_string(),
             "Lane entries are not in the right order"
         );
+
         // Final case: message is correct
-        let signed_msg = crypto2.sign(MempoolNetMessage::SyncReply(vec![LaneEntry {
-            data_proposal: data_proposal.clone(),
-            cumul_size,
-            signatures: vec![crypto2
-                .sign(MempoolNetMessage::DataVote(
-                    data_proposal.hashed(),
-                    cumul_size,
-                ))
-                .expect("should sign")],
-        }]))?;
+        let signed_msg = crypto2.sign(MempoolNetMessage::SyncReply(vec![(
+            LaneEntryMetadata {
+                parent_data_proposal_hash: None,
+                cumul_size,
+                signatures: vec![crypto2
+                    .sign(MempoolNetMessage::DataVote(
+                        data_proposal.hashed(),
+                        cumul_size,
+                    ))
+                    .expect("should sign")],
+            },
+            data_proposal.clone(),
+        )]))?;
 
         let handle = ctx.mempool.handle_net_message(signed_msg.clone());
         assert_ok!(handle, "Should handle net message");

--- a/src/mempool/storage.rs
+++ b/src/mempool/storage.rs
@@ -22,8 +22,8 @@ pub enum CanBePutOnTop {
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LaneEntry {
-    pub data_proposal: DataProposal,
+pub struct LaneEntryMetadata {
+    pub parent_data_proposal_hash: Option<DataProposalHash>,
     pub cumul_size: LaneBytesSize,
     pub signatures: Vec<SignedByValidator<MempoolNetMessage>>,
 }
@@ -32,14 +32,28 @@ pub trait Storage {
     fn persist(&self) -> Result<()>;
 
     fn contains(&self, lane_id: &LaneId, dp_hash: &DataProposalHash) -> bool;
-    fn get_by_hash(
+    fn get_metadata_by_hash(
         &self,
         lane_id: &LaneId,
         dp_hash: &DataProposalHash,
-    ) -> Result<Option<LaneEntry>>;
-    fn pop(&mut self, lane_id: LaneId) -> Result<Option<(DataProposalHash, LaneEntry)>>;
-    fn put(&mut self, lane_id: LaneId, lane_entry: LaneEntry) -> Result<()>;
-    fn put_no_verification(&mut self, lane_id: LaneId, lane_entry: LaneEntry) -> Result<()>;
+    ) -> Result<Option<LaneEntryMetadata>>;
+    fn get_dp_by_hash(
+        &self,
+        lane_id: &LaneId,
+        dp_hash: &DataProposalHash,
+    ) -> Result<Option<DataProposal>>;
+
+    fn pop(
+        &mut self,
+        lane_id: LaneId,
+    ) -> Result<Option<(DataProposalHash, (LaneEntryMetadata, DataProposal))>>;
+    fn put(&mut self, lane_id: LaneId, entry: (LaneEntryMetadata, DataProposal)) -> Result<()>;
+    fn put_no_verification(
+        &mut self,
+        lane_id: LaneId,
+        entry: (LaneEntryMetadata, DataProposal),
+    ) -> Result<()>;
+
     fn add_signatures<T: IntoIterator<Item = SignedByValidator<MempoolNetMessage>>>(
         &mut self,
         lane_id: &LaneId,
@@ -69,7 +83,7 @@ pub trait Storage {
         // We start from the tip of the lane, and go backup until we find a DP with enough signatures
         if let Some(tip_dp_hash) = self.get_lane_hash_tip(lane_id) {
             let mut dp_hash = tip_dp_hash.clone();
-            while let Some(le) = self.get_by_hash(lane_id, &dp_hash)? {
+            while let Some(le) = self.get_metadata_by_hash(lane_id, &dp_hash)? {
                 if let Some((hash, poda)) = previous_committed_car {
                     if &dp_hash == hash {
                         // Latest car has already been committed
@@ -97,8 +111,7 @@ pub trait Storage {
                 let f = staking.compute_f();
                 if voting_power < f + 1 {
                     // Check if previous DataProposals received enough votes
-                    if let Some(parent_dp_hash) = le.data_proposal.parent_data_proposal_hash.clone()
-                    {
+                    if let Some(parent_dp_hash) = le.parent_data_proposal_hash.clone() {
                         dp_hash = parent_dp_hash;
                         continue;
                     }
@@ -146,21 +159,33 @@ pub trait Storage {
         // FIXME: Investigate if we can directly use put_no_verification
         self.put(
             lane_id.clone(),
-            LaneEntry {
+            (
+                LaneEntryMetadata {
+                    parent_data_proposal_hash: data_proposal.parent_data_proposal_hash.clone(),
+                    cumul_size,
+                    signatures,
+                },
                 data_proposal,
-                cumul_size,
-                signatures,
-            },
+            ),
         )?;
         Ok((data_proposal_hash, cumul_size))
     }
 
-    fn get_lane_entries_between_hashes(
+    // Implemented in the actual modules to potentially benefit from optimizations
+    // in the underlying storage
+    fn get_entries_between_hashes(
         &self,
         lane_id: &LaneId,
         from_data_proposal_hash: Option<&DataProposalHash>,
         to_data_proposal_hash: Option<&DataProposalHash>,
-    ) -> Result<Vec<LaneEntry>> {
+    ) -> Result<Vec<(LaneEntryMetadata, DataProposal)>>;
+
+    fn get_entries_metadata_between_hashes(
+        &self,
+        lane_id: &LaneId,
+        from_data_proposal_hash: Option<&DataProposalHash>,
+        to_data_proposal_hash: Option<&DataProposalHash>,
+    ) -> Result<Vec<(LaneEntryMetadata, DataProposalHash)>> {
         // If no dp hash is provided, we use the tip of the lane
         let mut dp_hash: DataProposalHash = match to_data_proposal_hash {
             Some(hash) => hash.clone(),
@@ -173,13 +198,11 @@ pub trait Storage {
         };
         let mut entries = vec![];
         while Some(&dp_hash) != from_data_proposal_hash {
-            let lane_entry = self.get_by_hash(lane_id, &dp_hash)?;
+            let lane_entry = self.get_metadata_by_hash(lane_id, &dp_hash)?;
             match lane_entry {
                 Some(lane_entry) => {
-                    entries.insert(0, lane_entry.clone());
-                    if let Some(parent_dp_hash) =
-                        lane_entry.data_proposal.parent_data_proposal_hash.clone()
-                    {
+                    entries.insert(0, (lane_entry.clone(), dp_hash.clone()));
+                    if let Some(parent_dp_hash) = lane_entry.parent_data_proposal_hash.clone() {
                         dp_hash = parent_dp_hash;
                     } else {
                         break;
@@ -199,17 +222,17 @@ pub trait Storage {
         lane_id: &LaneId,
         dp_hash: &DataProposalHash,
     ) -> Result<LaneBytesSize> {
-        self.get_by_hash(lane_id, dp_hash)?.map_or_else(
+        self.get_metadata_by_hash(lane_id, dp_hash)?.map_or_else(
             || Ok(LaneBytesSize::default()),
             |entry| Ok(entry.cumul_size),
         )
     }
 
-    fn get_lane_pending_entries(
+    fn get_pending_entries_in_lane(
         &self,
         lane_id: &LaneId,
         last_cut: Option<Cut>,
-    ) -> Result<Vec<LaneEntry>> {
+    ) -> Result<Vec<(LaneEntryMetadata, DataProposalHash)>> {
         let lane_tip = self.get_lane_hash_tip(lane_id);
 
         let last_committed_dp_hash = match last_cut {
@@ -219,7 +242,7 @@ pub trait Storage {
                 .map(|(_, dp, _, _)| dp.clone()),
             None => None,
         };
-        self.get_lane_entries_between_hashes(lane_id, last_committed_dp_hash.as_ref(), lane_tip)
+        self.get_entries_metadata_between_hashes(lane_id, last_committed_dp_hash.as_ref(), lane_tip)
     }
 
     /// For unknown DataProposals in the new cut, we need to remove all DataProposals that we have after the previous cut.
@@ -302,17 +325,26 @@ mod tests {
         let data_proposal = DataProposal::new(None, vec![]);
         let cumul_size: LaneBytesSize = LaneBytesSize(data_proposal.estimate_size() as u64);
 
-        let entry = LaneEntry {
-            data_proposal,
+        let entry = LaneEntryMetadata {
+            parent_data_proposal_hash: None,
             cumul_size,
             signatures: vec![],
         };
-        let dp_hash = entry.data_proposal.hashed();
-        storage.put(lane_id.clone(), entry.clone()).unwrap();
+        let dp_hash = data_proposal.hashed();
+        storage
+            .put(lane_id.clone(), (entry.clone(), data_proposal.clone()))
+            .unwrap();
         assert!(storage.contains(lane_id, &dp_hash));
         assert_eq!(
-            storage.get_by_hash(lane_id, &dp_hash).unwrap().unwrap(),
+            storage
+                .get_metadata_by_hash(lane_id, &dp_hash)
+                .unwrap()
+                .unwrap(),
             entry
+        );
+        assert_eq!(
+            storage.get_dp_by_hash(lane_id, &dp_hash).unwrap().unwrap(),
+            data_proposal
         );
     }
 
@@ -323,13 +355,15 @@ mod tests {
         let mut storage = setup_storage();
         let data_proposal = DataProposal::new(None, vec![]);
         let cumul_size: LaneBytesSize = LaneBytesSize(data_proposal.estimate_size() as u64);
-        let mut entry = LaneEntry {
-            data_proposal,
+        let mut entry = LaneEntryMetadata {
+            parent_data_proposal_hash: None,
             cumul_size,
             signatures: vec![],
         };
-        let dp_hash = entry.data_proposal.hashed();
-        storage.put(lane_id.clone(), entry.clone()).unwrap();
+        let dp_hash = data_proposal.hashed();
+        storage
+            .put(lane_id.clone(), (entry.clone(), data_proposal.clone()))
+            .unwrap();
         entry.signatures.push(SignedByValidator {
             msg: MempoolNetMessage::DataVote(dp_hash.clone(), cumul_size),
             signature: ValidatorSignature {
@@ -338,9 +372,12 @@ mod tests {
             },
         });
         storage
-            .put_no_verification(lane_id.clone(), entry.clone())
+            .put_no_verification(lane_id.clone(), (entry.clone(), data_proposal.clone()))
             .unwrap();
-        let updated = storage.get_by_hash(lane_id, &dp_hash).unwrap().unwrap();
+        let updated = storage
+            .get_metadata_by_hash(lane_id, &dp_hash)
+            .unwrap()
+            .unwrap();
         assert_eq!(1, updated.signatures.len());
     }
 
@@ -358,7 +395,10 @@ mod tests {
             .store_data_proposal(&crypto, lane_id, data_proposal)
             .unwrap();
 
-        let lane_entry = storage.get_by_hash(lane_id, &dp_hash).unwrap().unwrap();
+        let lane_entry = storage
+            .get_metadata_by_hash(lane_id, &dp_hash)
+            .unwrap()
+            .unwrap();
         assert_eq!(1, lane_entry.signatures.len());
 
         // 2 votes on this DP
@@ -394,7 +434,10 @@ mod tests {
             .add_signatures(lane_id2, &dp_hash, std::iter::once(signed_msg))
             .unwrap();
 
-        let lane_entry = storage.get_by_hash(lane_id2, &dp_hash).unwrap().unwrap();
+        let lane_entry = storage
+            .get_metadata_by_hash(lane_id2, &dp_hash)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             2,
             lane_entry.signatures.len(),
@@ -424,44 +467,44 @@ mod tests {
 
         // [start, end] == [1, 2, 3]
         let all_entries = storage
-            .get_lane_entries_between_hashes(lane_id, None, None)
+            .get_entries_between_hashes(lane_id, None, None)
             .unwrap();
         assert_eq!(3, all_entries.len());
 
         // ]1, end] == [2, 3]
         let entries_from_1_to_end = storage
-            .get_lane_entries_between_hashes(lane_id, Some(&dp1.hashed()), None)
+            .get_entries_between_hashes(lane_id, Some(&dp1.hashed()), None)
             .unwrap();
         assert_eq!(2, entries_from_1_to_end.len());
-        assert_eq!(dp2, entries_from_1_to_end.first().unwrap().data_proposal);
-        assert_eq!(dp3, entries_from_1_to_end.last().unwrap().data_proposal);
+        assert_eq!(dp2, entries_from_1_to_end.first().unwrap().1);
+        assert_eq!(dp3, entries_from_1_to_end.last().unwrap().1);
 
         // [start, 2] == [1, 2]
         let entries_from_start_to_2 = storage
-            .get_lane_entries_between_hashes(lane_id, None, Some(&dp2.hashed()))
+            .get_entries_between_hashes(lane_id, None, Some(&dp2.hashed()))
             .unwrap();
         assert_eq!(2, entries_from_start_to_2.len());
-        assert_eq!(dp1, entries_from_start_to_2.first().unwrap().data_proposal);
-        assert_eq!(dp2, entries_from_start_to_2.last().unwrap().data_proposal);
+        assert_eq!(dp1, entries_from_start_to_2.first().unwrap().1);
+        assert_eq!(dp2, entries_from_start_to_2.last().unwrap().1);
 
         // ]1, 2] == [2]
         let entries_from_1_to_2 = storage
-            .get_lane_entries_between_hashes(lane_id, Some(&dp1.hashed()), Some(&dp2.hashed()))
+            .get_entries_between_hashes(lane_id, Some(&dp1.hashed()), Some(&dp2.hashed()))
             .unwrap();
         assert_eq!(1, entries_from_1_to_2.len());
-        assert_eq!(dp2, entries_from_1_to_2.first().unwrap().data_proposal);
+        assert_eq!(dp2, entries_from_1_to_2.first().unwrap().1);
 
         // ]1, 3] == [2, 3]
         let entries_from_1_to_3 = storage
-            .get_lane_entries_between_hashes(lane_id, Some(&dp1.hashed()), None)
+            .get_entries_between_hashes(lane_id, Some(&dp1.hashed()), None)
             .unwrap();
         assert_eq!(2, entries_from_1_to_3.len());
-        assert_eq!(dp2, entries_from_1_to_3.first().unwrap().data_proposal);
-        assert_eq!(dp3, entries_from_1_to_3.last().unwrap().data_proposal);
+        assert_eq!(dp2, entries_from_1_to_3.first().unwrap().1);
+        assert_eq!(dp3, entries_from_1_to_3.last().unwrap().1);
 
         // ]1, 1[ == []
         let entries_from_1_to_1 = storage
-            .get_lane_entries_between_hashes(lane_id, Some(&dp1.hashed()), Some(&dp1.hashed()))
+            .get_entries_between_hashes(lane_id, Some(&dp1.hashed()), Some(&dp1.hashed()))
             .unwrap();
         assert_eq!(0, entries_from_1_to_1.len());
     }
@@ -504,13 +547,15 @@ mod tests {
         let mut storage = setup_storage();
         let data_proposal = DataProposal::new(None, vec![]);
         let cumul_size: LaneBytesSize = LaneBytesSize(data_proposal.estimate_size() as u64);
-        let entry = LaneEntry {
-            data_proposal,
+        let entry = LaneEntryMetadata {
+            parent_data_proposal_hash: None,
             cumul_size,
             signatures: vec![],
         };
-        storage.put(lane_id.clone(), entry).unwrap();
-        let pending = storage.get_lane_pending_entries(lane_id, None).unwrap();
+        storage
+            .put(lane_id.clone(), (entry, data_proposal))
+            .unwrap();
+        let pending = storage.get_pending_entries_in_lane(lane_id, None).unwrap();
         assert_eq!(1, pending.len());
     }
 
@@ -522,12 +567,14 @@ mod tests {
         let staking = Staking::new();
         let data_proposal = DataProposal::new(None, vec![]);
         let cumul_size: LaneBytesSize = LaneBytesSize(data_proposal.estimate_size() as u64);
-        let entry = LaneEntry {
-            data_proposal,
+        let entry = LaneEntryMetadata {
+            parent_data_proposal_hash: None,
             cumul_size,
             signatures: vec![],
         };
-        storage.put(lane_id.clone(), entry).unwrap();
+        storage
+            .put(lane_id.clone(), (entry, data_proposal))
+            .unwrap();
         let latest = storage.get_latest_car(lane_id, &staking, None).unwrap();
         assert!(latest.is_none());
     }

--- a/src/mempool/storage_memory.rs
+++ b/src/mempool/storage_memory.rs
@@ -8,15 +8,15 @@ use hyle_model::{LaneBytesSize, LaneId, Signed, SignedByValidator, ValidatorSign
 use tracing::info;
 
 use super::{
-    storage::{CanBePutOnTop, LaneEntry, Storage},
+    storage::{CanBePutOnTop, LaneEntryMetadata, Storage},
     MempoolNetMessage,
 };
-use crate::model::{DataProposalHash, Hashed};
+use crate::model::{DataProposal, DataProposalHash, Hashed};
 
 pub struct LanesStorage {
     pub lanes_tip: BTreeMap<LaneId, (DataProposalHash, LaneBytesSize)>,
-    // NB: do not iterate on this one as it's unordered
-    pub by_hash: HashMap<LaneId, HashMap<DataProposalHash, LaneEntry>>,
+    // NB: do not iterate on these as they're unordered
+    pub by_hash: HashMap<LaneId, HashMap<DataProposalHash, (LaneEntryMetadata, DataProposal)>>,
 }
 
 impl LanesStorage {
@@ -45,56 +45,61 @@ impl Storage for LanesStorage {
         false
     }
 
-    fn get_by_hash(
+    fn get_metadata_by_hash(
         &self,
         lane_id: &LaneId,
         dp_hash: &DataProposalHash,
-    ) -> Result<Option<LaneEntry>> {
+    ) -> Result<Option<LaneEntryMetadata>> {
         if let Some(lane) = self.by_hash.get(lane_id) {
-            return Ok(lane.get(dp_hash).cloned());
+            return Ok(lane.get(dp_hash).map(|(metadata, _)| metadata.clone()));
+        }
+        bail!("Can't find validator {}", lane_id)
+    }
+    fn get_dp_by_hash(
+        &self,
+        lane_id: &LaneId,
+        dp_hash: &DataProposalHash,
+    ) -> Result<Option<DataProposal>> {
+        if let Some(lane) = self.by_hash.get(lane_id) {
+            return Ok(lane.get(dp_hash).map(|(_, data)| data.clone()));
         }
         bail!("Can't find validator {}", lane_id)
     }
 
-    fn pop(&mut self, validator: LaneId) -> Result<Option<(DataProposalHash, LaneEntry)>> {
+    fn pop(
+        &mut self,
+        validator: LaneId,
+    ) -> Result<Option<(DataProposalHash, (LaneEntryMetadata, DataProposal))>> {
         if let Some((lane_tip, _)) = self.lanes_tip.get(&validator).cloned() {
             if let Some(lane) = self.by_hash.get_mut(&validator) {
-                if let Some(lane_entry) = lane.remove(&lane_tip) {
-                    self.update_lane_tip(
-                        validator,
-                        lane_entry.data_proposal.hashed(),
-                        lane_entry.cumul_size,
-                    );
-                    return Ok(Some((lane_tip.clone(), lane_entry)));
+                if let Some(entry) = lane.remove(&lane_tip) {
+                    self.update_lane_tip(validator, lane_tip.clone(), entry.0.cumul_size);
+                    return Ok(Some((lane_tip.clone(), entry)));
                 }
             }
         }
         Ok(None)
     }
 
-    fn put(&mut self, lane_id: LaneId, lane_entry: LaneEntry) -> Result<()> {
-        let dp_hash = lane_entry.data_proposal.hashed();
+    fn put(&mut self, lane_id: LaneId, entry: (LaneEntryMetadata, DataProposal)) -> Result<()> {
+        let dp_hash = entry.1.hashed();
         if self.contains(&lane_id, &dp_hash) {
             bail!("DataProposal {} was already in lane", dp_hash);
         }
-        match self.can_be_put_on_top(
-            &lane_id,
-            lane_entry.data_proposal.parent_data_proposal_hash.as_ref(),
-        ) {
+        match self.can_be_put_on_top(&lane_id, entry.0.parent_data_proposal_hash.as_ref()) {
             CanBePutOnTop::No => bail!(
                 "Can't store DataProposal {}, as parent is unknown ",
-                lane_entry.data_proposal.hashed()
+                dp_hash
             ),
             CanBePutOnTop::Yes => {
-                // Add DataProposal to validator's lane
-                let size = lane_entry.cumul_size;
+                // Add both metadata and data to validator's lane
                 self.by_hash
                     .entry(lane_id.clone())
                     .or_default()
-                    .insert(dp_hash.clone(), lane_entry);
+                    .insert(dp_hash.clone(), entry.clone());
 
-                // Validatoupdate_lane_tipr's lane tip is only updated if DP-chain is respected
-                self.update_lane_tip(lane_id, dp_hash, size);
+                // Validator's lane tip is only updated if DP-chain is respected
+                self.update_lane_tip(lane_id, dp_hash, entry.0.cumul_size);
 
                 Ok(())
             }
@@ -103,18 +108,22 @@ impl Storage for LanesStorage {
                 bail!(
                     "DataProposal cannot be put in lane because it creates a fork: last dp hash {:?} while proposed parent_data_proposal_hash: {:?}",
                     last_known_hash,
-                    lane_entry.data_proposal.parent_data_proposal_hash
+                    entry.0.parent_data_proposal_hash
                 )
             }
         }
     }
 
-    fn put_no_verification(&mut self, lane_id: LaneId, lane_entry: LaneEntry) -> Result<()> {
-        let dp_hash = lane_entry.data_proposal.hashed();
+    fn put_no_verification(
+        &mut self,
+        lane_id: LaneId,
+        entry: (LaneEntryMetadata, DataProposal),
+    ) -> Result<()> {
+        let dp_hash = entry.1.hashed();
         self.by_hash
             .entry(lane_id)
             .or_default()
-            .insert(dp_hash, lane_entry);
+            .insert(dp_hash, entry);
         Ok(())
     }
 
@@ -124,12 +133,12 @@ impl Storage for LanesStorage {
         dp_hash: &DataProposalHash,
         vote_msgs: T,
     ) -> Result<Vec<Signed<MempoolNetMessage, ValidatorSignature>>> {
-        let Some(dp) = self
-            .by_hash
-            .get_mut(lane_id)
-            .and_then(|lane| lane.get_mut(dp_hash))
-        else {
-            bail!("DataProposal {} not found in lane {}", dp_hash, lane_id);
+        let Some(lane) = self.by_hash.get_mut(lane_id) else {
+            bail!("Can't find validator {}", lane_id);
+        };
+
+        let Some((mut metadata, data_proposal)) = lane.get(dp_hash).cloned() else {
+            bail!("Can't find DP {} for validator {}", dp_hash, lane_id);
         };
 
         for msg in vote_msgs {
@@ -140,7 +149,7 @@ impl Storage for LanesStorage {
                 );
                 continue;
             };
-            if &dp.cumul_size != cumul_size || dp_hash != dph {
+            if &metadata.cumul_size != cumul_size || dp_hash != dph {
                 tracing::warn!(
                     "Received a DataVote message with wrong hash or size: {:?}",
                     msg.msg
@@ -148,15 +157,17 @@ impl Storage for LanesStorage {
                 continue;
             }
             // Insert the new messages if they're not already in
-            match dp
+            match metadata
                 .signatures
                 .binary_search_by(|probe| probe.signature.cmp(&msg.signature))
             {
                 Ok(_) => {}
-                Err(pos) => dp.signatures.insert(pos, msg),
+                Err(pos) => metadata.signatures.insert(pos, msg),
             }
         }
-        Ok(dp.signatures.clone())
+        let signatures = metadata.signatures.clone();
+        lane.insert(dp_hash.clone(), (metadata, data_proposal));
+        Ok(signatures)
     }
 
     fn get_lane_ids(&self) -> impl Iterator<Item = &LaneId> {
@@ -178,6 +189,27 @@ impl Storage for LanesStorage {
         size: LaneBytesSize,
     ) -> Option<(DataProposalHash, LaneBytesSize)> {
         self.lanes_tip.insert(lane_id, (dp_hash, size))
+    }
+
+    fn get_entries_between_hashes(
+        &self,
+        lane_id: &LaneId,
+        from_data_proposal_hash: Option<&DataProposalHash>,
+        to_data_proposal_hash: Option<&DataProposalHash>,
+    ) -> Result<Vec<(LaneEntryMetadata, DataProposal)>> {
+        let metadata = self.get_entries_metadata_between_hashes(
+            lane_id,
+            from_data_proposal_hash,
+            to_data_proposal_hash,
+        )?;
+        let mut entries = Vec::with_capacity(metadata.len());
+        for (metadata, dp_hash) in metadata {
+            let Some(dp) = self.get_dp_by_hash(lane_id, &dp_hash)? else {
+                bail!("Can't find DP {} for validator {}", dp_hash, lane_id);
+            };
+            entries.push((metadata, dp));
+        }
+        Ok(entries)
     }
 
     #[cfg(test)]

--- a/src/mempool/storage_memory.rs
+++ b/src/mempool/storage_memory.rs
@@ -53,7 +53,7 @@ impl Storage for LanesStorage {
         if let Some(lane) = self.by_hash.get(lane_id) {
             return Ok(lane.get(dp_hash).map(|(metadata, _)| metadata.clone()));
         }
-        bail!("Can't find validator {}", lane_id)
+        bail!("Can't find lane with ID {}", lane_id)
     }
     fn get_dp_by_hash(
         &self,

--- a/src/tests/autobahn_testing.rs
+++ b/src/tests/autobahn_testing.rs
@@ -607,6 +607,7 @@ async fn mempool_podaupdate_too_early() {
             node.mempool_ctx
                 .last_lane_entry(&lane_id)
                 .0
+                 .0
                 .signatures
                 .len(),
             n


### PR DESCRIPTION
- Makes it faster to update signatures since we don't need to compress/decompress so much data
- Makes it workable to quickly get pending DPs and still only process one