### PR TITLE
🔒 Fail to process wrong blocks in node_state

### DIFF
--- a/src/data_availability.rs
+++ b/src/data_availability.rs
@@ -489,15 +489,19 @@ pub mod tests {
             block: SignedBlock,
             tcp_server: &mut DaTcpServer,
         ) {
-            let full_block = self.node_state.handle_signed_block(&block);
+            _ = log_error!(
+                self.da.handle_signed_block(block.clone(), tcp_server).await,
+                "Handling Signed Block"
+            );
+            // TODO: we use this in autobahn_testing, but it'd be cleaner to separate it.
+            let Ok(full_block) = self.node_state.handle_signed_block(&block) else {
+                tracing::warn!("Error while handling signed block {}", block.hashed());
+                return;
+            };
             _ = log_error!(
                 self.node_state_bus
                     .send(NodeStateEvent::NewBlock(Box::new(full_block))),
                 "Sending NodeState event"
-            );
-            _ = log_error!(
-                self.da.handle_signed_block(block, tcp_server).await,
-                "Handling Signed Block"
             );
         }
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1059,11 +1059,12 @@ mod test {
 
         let parent_data_proposal = DataProposal::new(None, txs);
         let mut signed_block = SignedBlock::default();
+        signed_block.consensus_proposal.slot = 1;
         signed_block.data_proposals.push((
             LaneId(ValidatorPublicKey("ttt".into())),
             vec![parent_data_proposal.clone()],
         ));
-        let block = node_state.handle_signed_block(&signed_block);
+        let block = node_state.force_handle_block(&signed_block);
 
         indexer
             .handle_processed_block(block)
@@ -1209,7 +1210,7 @@ mod test {
             LaneId(ValidatorPublicKey("ttt".into())),
             vec![data_proposal],
         ));
-        let block_2 = node_state.handle_signed_block(&signed_block);
+        let block_2 = node_state.force_handle_block(&signed_block);
         let block_2_hash = block_2.hash.clone();
         indexer
             .handle_processed_block(block_2)
@@ -1294,7 +1295,7 @@ mod test {
                 }
             ])
         );
-        let all_txs = server.get("/transactions/block/0").await;
+        let all_txs = server.get("/transactions/block/1").await;
         all_txs.assert_status_ok();
         assert_json_include!(
             actual: all_txs.json::<serde_json::Value>(),
@@ -1344,7 +1345,7 @@ mod test {
             ])
         );
 
-        let proofs_by_height = server.get("/proofs/block/0").await;
+        let proofs_by_height = server.get("/proofs/block/1").await;
         proofs_by_height.assert_status_ok();
         assert_json_include!(
             actual: proofs_by_height.json::<serde_json::Value>(),

--- a/src/indexer/contract_state_indexer.rs
+++ b/src/indexer/contract_state_indexer.rs
@@ -474,7 +474,9 @@ mod tests {
             metrics: NodeStateMetrics::global("test".to_string(), "test"),
             store: NodeStateStore::default(),
         };
-        let block = node_state.handle_signed_block(&SignedBlock::default());
+        let block = node_state
+            .handle_signed_block(&SignedBlock::default())
+            .unwrap();
 
         let event = NodeStateEvent::NewBlock(Box::new(block));
 

--- a/src/indexer/da_listener.rs
+++ b/src/indexer/da_listener.rs
@@ -134,7 +134,7 @@ impl DAListener {
                 block.consensus_proposal.slot,
                 block.consensus_proposal.hashed()
             );
-            let block = self.node_state.handle_signed_block(&block);
+            let block = self.node_state.handle_signed_block(&block)?;
             debug!("📦 Handled block outputs: {:?}", block);
 
             self.bus.send(NodeStateEvent::NewBlock(Box::new(block)))?;

--- a/src/node_state/module.rs
+++ b/src/node_state/module.rs
@@ -99,7 +99,8 @@ impl Module for NodeStateModule {
             listen<DataEvent> block => {
                 match block {
                     DataEvent::OrderedSignedBlock(block) => {
-                        let node_state_block = self.inner.handle_signed_block(&block);
+                        // TODO: If we are in a broken state, this will likely kill the node every time.
+                        let node_state_block = self.inner.handle_signed_block(&block)?;
                         _ = log_error!(self
                             .bus
                             .send(NodeStateEvent::NewBlock(Box::new(node_state_block))), "Sending DataEvent while processing SignedBlock");


### PR DESCRIPTION
This used to error out, but it should probably kill the node instead.