### PR TITLE
⚡️ Optimise DP dissemination

### DIFF
--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -337,7 +337,10 @@ impl Mempool {
             Duration::from_millis(500),
         );
         let mut new_dp_timer = tokio::time::interval(tick_interval);
-        let mut disseminate_timer = tokio::time::interval(Duration::from_secs(3));
+        // We always disseminate new data proposals, so we can run the re-dissemination timer
+        // infrequently, as it will only be useful if we had a network issue that lead
+        // to a PoDA not being created.
+        let mut disseminate_timer = tokio::time::interval(Duration::from_secs(15));
         new_dp_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         disseminate_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     utils::{
         conf::{P2pMode, SharedConf},
+        ordered_join_set::OrderedJoinSet,
         serialize::arc_rwlock_borsh,
     },
 };
@@ -37,7 +38,7 @@ use std::{
     time::Duration,
 };
 use storage::{LaneEntryMetadata, Storage};
-use tokio::task::{JoinHandle, JoinSet};
+use tokio::task::JoinSet;
 use verify_tx::DataProposalVerdict;
 // Pick one of the two implementations
 // use storage_memory::LanesStorage;
@@ -100,9 +101,7 @@ pub struct MempoolStore {
     // TODO: implement serialization, probably with a custom future that yields the unmodified Tx
     // on cancellation
     #[borsh(skip)]
-    processing_txs: VecDeque<JoinHandle<Result<Transaction>>>,
-    #[borsh(skip)]
-    notify_new_tx_to_process: tokio::sync::Notify,
+    processing_txs: OrderedJoinSet<Result<Transaction>>,
     waiting_dissemination_txs: Vec<Transaction>,
     #[borsh(skip)]
     own_data_proposal_in_preparation: JoinSet<(DataProposalHash, DataProposal)>,
@@ -111,7 +110,7 @@ pub struct MempoolStore {
 
     // verify_tx.rs
     #[borsh(skip)]
-    processing_dps: JoinSet<Result<ProcessedDPEvent>>,
+    processing_dps: OrderedJoinSet<Result<ProcessedDPEvent>>,
     #[borsh(skip)]
     cached_dp_votes: HashMap<(LaneId, DataProposalHash), DataProposalVerdict>,
 
@@ -387,29 +386,7 @@ impl Mempool {
                 }
             }
             // own_lane.rs code below
-            // This is inlined to avoid double-self mutable borrow.
-            // Essentially we just wait for a tx to appear in processing_txs.
-            tx = async {
-                loop {
-                    if self
-                        .inner.processing_txs
-                        .front()
-                        .is_some_and(|jh| jh.is_finished())
-                    {
-                        #[allow(clippy::unwrap_used, reason = "checked above")]
-                        let processing_tx = self.inner.processing_txs.pop_front().unwrap();
-                        match processing_tx.await {
-                            Err(e) => {
-                                tracing::error!("Error joining task: {:?}", e);
-                                continue;
-                            }
-                            Ok(els) => return els,
-                        }
-                    } else {
-                        self.inner.notify_new_tx_to_process.notified().await;
-                    }
-                }
-            } => {
+            Some(Ok(tx)) = self.inner.processing_txs.join_next() => {
                 match tx {
                     Ok(tx) => {
                         let _ = log_error!(self.on_new_tx(tx), "Handling tx in Mempool");

--- a/src/mempool/own_lane.rs
+++ b/src/mempool/own_lane.rs
@@ -115,10 +115,10 @@ impl super::Mempool {
             .get_pending_entries_in_lane(&self.own_lane_id(), last_cut)?;
 
         for (entry_metadata, dp_hash) in entries {
-            // If only_dp_with_hash is Some, we only disseminate that one, so break and exit in all other cases.
+            // If only_dp_with_hash is Some, we only disseminate that one, skip all others.
             if let Some(ref only_dp_with_hash) = only_dp_with_hash {
                 if &dp_hash != only_dp_with_hash {
-                    break;
+                    continue;
                 }
             }
             let Some(data_proposal) = self.lanes.get_dp_by_hash(&self.own_lane_id(), &dp_hash)?

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,4 +2,5 @@
 pub mod conf;
 pub mod integration_test;
 pub mod modules;
+pub mod ordered_join_set;
 pub mod serialize;

--- a/src/utils/ordered_join_set.rs
+++ b/src/utils/ordered_join_set.rs
@@ -1,0 +1,145 @@
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+
+/// A JoinSet that maintains the order of tasks.
+/// Tasks are processed in FIFO order, and only one task can be processed at a time.
+pub struct OrderedJoinSet<T> {
+    tasks: VecDeque<JoinHandle<T>>,
+}
+
+impl<T> OrderedJoinSet<T> {
+    pub fn new() -> Self {
+        Self {
+            tasks: VecDeque::new(),
+        }
+    }
+
+    /// Adds a new task to the set.
+    /// Tasks are awaited in a FIFO order.
+    pub fn spawn<F>(&mut self, task: F)
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.spawn_on(task, &Handle::current())
+    }
+
+    /// Adds a new task to the set, spawning it on the specified runtime handle.
+    /// Tasks are awaited in a FIFO order.
+    pub fn spawn_on<F>(&mut self, task: F, handle: &Handle)
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let handle = handle.spawn(task);
+        self.tasks.push_back(handle);
+    }
+
+    /// Returns true if the set contains no tasks.
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    /// Returns the number of tasks in the set.
+    pub fn len(&self) -> usize {
+        self.tasks.len()
+    }
+
+    /// Waits for the next task in order to complete.
+    /// Returns None if there are no tasks in the set.
+    pub async fn join_next(&mut self) -> Option<Result<T, tokio::task::JoinError>> {
+        std::future::poll_fn(|cx| self.poll_join_next(cx)).await
+    }
+
+    /// Polls for the next completed task in order.
+    fn poll_join_next(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<T, tokio::task::JoinError>>> {
+        match self.tasks.front_mut() {
+            Some(task) => {
+                if let Poll::Ready(result) = Pin::new(task).poll(cx) {
+                    self.tasks.pop_front();
+                    return Poll::Ready(Some(result));
+                }
+                // Not ready, try again next time
+                Poll::Pending
+            }
+            None => Poll::Ready(None),
+        }
+    }
+
+    /// Aborts all tasks in the set.
+    pub fn abort_all(&mut self) {
+        while let Some(task) = self.tasks.pop_front() {
+            task.abort();
+        }
+    }
+}
+
+impl<T> Default for OrderedJoinSet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Drop for OrderedJoinSet<T> {
+    fn drop(&mut self) {
+        self.abort_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_ordered_join_set() {
+        let mut set = OrderedJoinSet::new();
+
+        // Spawn tasks that complete in reverse order
+        set.spawn(async {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            1
+        });
+        set.spawn(async { 2 });
+        set.spawn(async { 3 });
+
+        // Tasks should complete in order despite different completion times
+        assert_eq!(set.join_next().await.unwrap().unwrap(), 1);
+        assert_eq!(set.join_next().await.unwrap().unwrap(), 2);
+        assert_eq!(set.join_next().await.unwrap().unwrap(), 3);
+        assert!(set.join_next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_empty_set() {
+        let mut set = OrderedJoinSet::<i32>::new();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+        assert!(set.join_next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_abort_all() {
+        let mut set = OrderedJoinSet::new();
+
+        set.spawn(async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            1
+        });
+        set.spawn(async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            2
+        });
+
+        assert_eq!(set.len(), 2);
+        set.abort_all();
+        assert!(set.is_empty());
+    }
+}


### PR DESCRIPTION
On DP creation, we always disseminate it. Because we send in order, they will be processed in order so in general things work perfectly. This means we can bump the retry timer to a much higher value, only for use in case of serious issues.