### PR TITLE
⚡️ Process buffered DP when done with one

### DIFF
--- a/crates/hyle-net/src/tcp/p2p_server.rs
+++ b/crates/hyle-net/src/tcp/p2p_server.rs
@@ -1073,7 +1073,7 @@ pub mod tests {
         // Process the waiting job.
         p2p_server1.listen_next().await;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
         let evt = receive_event(&mut p2p_server2, "Should be a TestMessage event").await?;
 
@@ -1100,7 +1100,7 @@ pub mod tests {
         // Process the waiting job.
         p2p_server1.listen_next().await;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
         let evt = receive_event(&mut p2p_server2, "Should be a TestMessage event").await?;
 
@@ -1127,7 +1127,7 @@ pub mod tests {
         // Process the waiting job.
         p2p_server2.listen_next().await;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
         let evt = receive_event(&mut p2p_server1, "Should be a TestMessage event").await?;
 
@@ -1154,7 +1154,7 @@ pub mod tests {
         // Process the waiting job.
         p2p_server2.listen_next().await;
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
         let evt = receive_event(&mut p2p_server1, "Should be a TestMessage event").await?;
 

--- a/src/mempool/verify_tx.rs
+++ b/src/mempool/verify_tx.rs
@@ -234,16 +234,16 @@ impl super::Mempool {
                 let mut dp = None;
                 if let Some(buffered_proposals) = self.buffered_proposals.get_mut(&lane_id) {
                     // Check if we have a buffered proposal that is a child of this DP
-                    let i = buffered_proposals.iter().position(|dp| {
+                    let child_idx = buffered_proposals.iter().position(|dp| {
                         if let Some(parent_hash) = &dp.parent_data_proposal_hash {
                             parent_hash == &hash
                         } else {
                             false
                         }
                     });
-                    if let Some(i) = i {
+                    if let Some(child_idx) = child_idx {
                         // We have a buffered proposal that is a child of this DP
-                        dp = Some(buffered_proposals.swap_remove(i));
+                        dp = Some(buffered_proposals.swap_remove(child_idx));
                     }
                 }
                 if let Some(dp) = dp {

--- a/src/mempool/verify_tx.rs
+++ b/src/mempool/verify_tx.rs
@@ -170,6 +170,7 @@ impl super::Mempool {
                 );
             }
             DataProposalVerdict::Wait => {
+                debug!("Buffering DataProposal");
                 // Push the data proposal in the waiting list
                 self.buffered_proposals
                     .entry(lane_id.clone())
@@ -227,6 +228,32 @@ impl super::Mempool {
                 {
                     self.on_poda_update(&lane_id, &hash, poda_signatures)
                         .context("Processing buffered poda")?;
+                }
+
+                // Check if we maybe buffered a descendant of this DP.
+                let mut dp = None;
+                if let Some(buffered_proposals) = self.buffered_proposals.get_mut(&lane_id) {
+                    // Check if we have a buffered proposal that is a child of this DP
+                    let i = buffered_proposals.iter().position(|dp| {
+                        if let Some(parent_hash) = &dp.parent_data_proposal_hash {
+                            parent_hash == &hash
+                        } else {
+                            false
+                        }
+                    });
+                    if let Some(i) = i {
+                        // We have a buffered proposal that is a child of this DP
+                        dp = Some(buffered_proposals.swap_remove(i));
+                    }
+                }
+                if let Some(dp) = dp {
+                    // We can process this DP
+                    debug!(
+                        "Processing buffered DataProposal {:?} on lane {}",
+                        dp.hashed(),
+                        lane_id
+                    );
+                    self.on_hashed_data_proposal(&lane_id, dp)?;
                 }
             }
             DataProposalVerdict::Refuse => {


### PR DESCRIPTION
This avoids a situation where we receive several DPS, and by the time the hashing of the second is done we haven't done processing the first. We'd buffer it and just forget about it.