### PR TITLE
Fix typo in transaction execution error message

### DIFF
--- a/crates/client-sdk/src/transaction_builder.rs
+++ b/crates/client-sdk/src/transaction_builder.rs
@@ -278,7 +278,7 @@ impl<S: StateUpdater> TxExecutor<S> {
                 }
                 let program_error = std::str::from_utf8(&out.program_outputs).unwrap();
                 bail!(
-                    "Execution failed on runner for blob {:?} on contrat {:?} ! Program output: {}",
+                    "Execution failed on runner for blob {:?} on contract {:?} ! Program output: {}",
                     runner.calldata.get().unwrap().index,
                     runner.contract_name,
                     program_error


### PR DESCRIPTION
Corrected a typo in the panic message string (contrat → contract) to improve readability and maintain consistent terminology in error reporting.