### PR TITLE
:sparkles:  WIP - Add method to init prover catchup from node_state store

### DIFF
--- a/crates/hyle-modules/src/node_state.rs
+++ b/crates/hyle-modules/src/node_state.rs
@@ -181,7 +181,7 @@ impl NodeStateStore {
     ) -> anyhow::Result<impl Iterator<Item = (TxId, &UnsettledBlobTransaction)>> {
         let tx_order = self
             .unsettled_transactions
-            .get_tx_order(&contract_name)
+            .get_tx_order(contract_name)
             .context("Get tx order for contract")?;
         Ok(tx_order.iter().filter_map(|tx_hash| {
             self.unsettled_transactions


### PR DESCRIPTION
 Missing
 - Move node state in Autoprover
 - init it and populate state with method