### PR TITLE
fix(client-sdk): correct SP1 Local prover type and test module execute call

### DIFF
--- a/crates/client-sdk/src/helpers.rs
+++ b/crates/client-sdk/src/helpers.rs
@@ -175,7 +175,7 @@ pub mod risc0 {
 pub mod sp1 {
     use sdk::ProofMetadata;
     use sp1_sdk::{
-        network::builder::NetworkProverBuilder, EnvProver, NetworkProver, ProverClient,
+        network::builder::NetworkProverBuilder, NetworkProver, ProverClient,
         SP1ProvingKey, SP1Stdin,
     };
 
@@ -187,7 +187,7 @@ pub mod sp1 {
     }
 
     enum ProverType {
-        Local(EnvProver),
+        Local(ProverClient),
         Network(Box<NetworkProver>),
     }
 
@@ -422,7 +422,7 @@ pub mod test {
             Box::pin(async move {
                 let mut proofs = Vec::new();
                 for call in calldata {
-                    let hyle_output = test::execute(commitment_metadata.clone(), call)?;
+                    let hyle_output = execute(commitment_metadata.clone(), call)?;
                     proofs.push(hyle_output);
                 }
                 Ok(Proof {


### PR DESCRIPTION
Replace EnvProver with ProverClient in ProverType::Local and adjust imports in sp1
Fix internal reference from test::execute to execute inside mod test
Ensures proper typing and avoids a self-module reference issue
Build verified with cargo build