### PR TITLE
fix(hyli-net): enforce http scheme and reject https

### DIFF
--- a/crates/hyli-net/src/http.rs
+++ b/crates/hyli-net/src/http.rs
@@ -37,6 +37,14 @@ impl HttpClient {
         let full_url = format!("{}{}", &self.url, endpoint);
         let uri: Uri = full_url.parse().context("Parsing URI")?;
 
+        let scheme = uri.scheme_str().unwrap_or("http");
+        if scheme != "http" {
+            anyhow::bail!(
+                "Unsupported URI scheme: {}. HTTPS is not implemented",
+                scheme
+            );
+        }
+
         let authority = uri.authority().context("URI Authority")?.clone();
         let host = authority.host().to_string();
         let port = authority.port_u16().unwrap_or(80);


### PR DESCRIPTION
The client previously ignored the URI scheme and always opened a plain TCP connection, defaulting to port 80 even for https URLs, which could lead to broken handshakes and confusing failures. This change validates the scheme and rejects non-http early with a clear error, aligning behavior with the current codebase that lacks TLS support and preventing silent misuse.