### PR TITLE
chore(consensus): remove empty cfg(test) impl block

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -963,9 +963,6 @@ impl Consensus {
 }
 
 #[cfg(test)]
-impl Consensus {}
-
-#[cfg(test)]
 pub mod test {
 
     use crate::{


### PR DESCRIPTION
Removes an empty #[cfg(test)] impl Consensus block with no methods